### PR TITLE
feat!: add position info to nodes

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,23 +128,32 @@ function text (scanner) {
  * <summary-sep>  ::= "!"? ":" *<whitespace>
  */
 function summarySep (scanner) {
+  const start = scanner.position()
   const node = {
     type: 'summary-sep',
     children: []
   }
   if (isSummarySep(scanner.peek())) {
-    // todo: position needs to be broken up for the `!:` token
     scanner.next()
+    // manually offset the end with half the "!:" size
+    const breakingEnd = scanner.position()
+    breakingEnd.offset--
+    breakingEnd.column--
     node.children.push({
       type: 'breaking-change',
-      value: '!'
+      value: '!',
+      position: { start, end: breakingEnd }
     })
+    // manually offset the start with half the "!:" size
+    const separatorStart = scanner.position()
+    separatorStart.offset--
+    separatorStart.column--
     node.children.push({
       type: 'separator',
-      value: ':'
+      value: ':',
+      position: { start: separatorStart, end: scanner.position() }
     })
   } else if (scanner.peek() === ':') {
-    const start = scanner.position()
     scanner.next()
     node.children.push({
       type: 'separator',

--- a/index.js
+++ b/index.js
@@ -410,8 +410,7 @@ function invalidToken (scanner, expected) {
     return Error(`unexpected token EOF valid tokens [${expected.join(', ')}]`)
   } else {
     const pos = scanner.position()
-    const posString = `{ line: ${pos.line}, column: ${pos.column}, offset: ${pos.offset} }`
-    return Error(`unexpected token '${scanner.peek()}' at position ${posString} valid tokens [${expected.join(', ')}]`)
+    return Error(`unexpected token '${scanner.peek()}' at position ${pos.line}:${pos.column} valid tokens [${expected.join(', ')}]`)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -140,8 +140,8 @@ function summarySep (scanner) {
     scanner.next()
     // manually offset the end with half the "!:" size
     const breakingEnd = scanner.position()
-    breakingEnd.offset--;
-    breakingEnd.column--;
+    breakingEnd.offset--
+    breakingEnd.column--
     node.children.push({
       type: 'breaking-change',
       value: '!',
@@ -149,8 +149,8 @@ function summarySep (scanner) {
     })
     // manually offset the start with half the "!:" size
     const separatorStart = scanner.position()
-    separatorStart.offset--;
-    separatorStart.column--;
+    separatorStart.offset--
+    separatorStart.column--
     node.children.push({
       type: 'separator',
       value: ':',

--- a/index.js
+++ b/index.js
@@ -19,7 +19,10 @@ function message (commitText) {
   } else {
     node.children.push(s)
   }
-  if (scanner.eof()) return node
+  if (scanner.eof()) {
+    node.position = { start, end: scanner.position() }
+    return node
+  }
 
   // <summary> <newline> <body-footer>
   if (isNewline(scanner.peek())) {
@@ -137,8 +140,8 @@ function summarySep (scanner) {
     scanner.next()
     // manually offset the end with half the "!:" size
     const breakingEnd = scanner.position()
-    breakingEnd.offset--
-    breakingEnd.column--
+    breakingEnd.offset--;
+    breakingEnd.column--;
     node.children.push({
       type: 'breaking-change',
       value: '!',
@@ -146,8 +149,8 @@ function summarySep (scanner) {
     })
     // manually offset the start with half the "!:" size
     const separatorStart = scanner.position()
-    separatorStart.offset--
-    separatorStart.column--
+    separatorStart.offset--;
+    separatorStart.column--;
     node.children.push({
       type: 'separator',
       value: ':',

--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -33,6 +33,7 @@ class Scanner {
 
   consumeWhitespace () {
     while (isWhitespace(this.peek())) {
+      this.pos.column++
       if (isNewline(this.peek())) {
         this.pos.line++
         this.pos.column = 1

--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -12,17 +12,19 @@ class Scanner {
   }
 
   next (n) {
-    if (n) {
-      const token = this.text.substring(this.pos.offset, this.pos.offset + n)
-      this.pos.offset += n
-      this.pos.column += n
-      return token
-    } else {
-      const token = this.peek()
-      this.pos.offset += token.length
-      this.pos.column += token.length
-      return token
+    const token = n
+      ? this.text.substring(this.pos.offset, this.pos.offset + n)
+      : this.peek()
+
+    this.pos.offset += token.length
+    this.pos.column += token.length
+
+    if (isNewline(token)) {
+      this.pos.line++
+      this.pos.column = 1
     }
+
+    return token
   }
 
   nextIgnoreWhitespace () {
@@ -33,12 +35,7 @@ class Scanner {
 
   consumeWhitespace () {
     while (isWhitespace(this.peek())) {
-      this.pos.column++
-      if (isNewline(this.peek())) {
-        this.pos.line++
-        this.pos.column = 1
-      }
-      this.pos.offset++
+      this.next()
     }
   }
 

--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -1,24 +1,26 @@
-const { isWhitespace } = require('./type-checks')
+const { isWhitespace, isNewline } = require('./type-checks')
 const { CR, LF } = require('./codes')
 
 class Scanner {
-  constructor (text) {
-    this.pos = 0
+  constructor (text, pos) {
     this.text = text
+    this.pos = pos ? { ...pos } : { line: 1, column: 1, offset: 0 }
   }
 
   eof () {
-    return this.pos >= this.text.length
+    return this.pos.offset >= this.text.length
   }
 
   next (n) {
     if (n) {
-      const token = this.text.substring(this.pos, this.pos + n)
-      this.pos += n
+      const token = this.text.substring(this.pos.offset, this.pos.offset + n)
+      this.pos.offset += n
+      this.pos.column += n
       return token
     } else {
       const token = this.peek()
-      this.pos += token.length
+      this.pos.offset += token.length
+      this.pos.column += token.length
       return token
     }
   }
@@ -31,29 +33,33 @@ class Scanner {
 
   consumeWhitespace () {
     while (isWhitespace(this.peek())) {
-      this.pos++
+      if (isNewline(this.peek())) {
+        this.pos.line++
+        this.pos.column = 1
+      }
+      this.pos.offset++
     }
   }
 
   peek () {
-    let token = this.text.charAt(this.pos)
+    let token = this.text.charAt(this.pos.offset)
     // Consume <CR>? <LF>
-    if (token === CR && this.text.charAt(this.pos + 1) === LF) {
+    if (token === CR && this.text.charAt(this.pos.offset + 1) === LF) {
       token += LF
     // Consume ?: separator
-    } else if (token === '!' && this.text.charAt(this.pos + 1) === ':') {
+    } else if (token === '!' && this.text.charAt(this.pos.offset + 1) === ':') {
       token += ':'
     }
     return token
   }
 
   peekLiteral (literal) {
-    const str = this.text.substring(this.pos, this.pos + literal.length)
+    const str = this.text.substring(this.pos.offset, this.pos.offset + literal.length)
     return literal === str
   }
 
   position () {
-    return this.pos
+    return { ...this.pos }
   }
 
   rewind (pos) {

--- a/test.js
+++ b/test.js
@@ -29,10 +29,10 @@ describe('<message>', () => {
     it('throws error when ":" token is missing', () => {
       expect(() => {
         parser('feat add support for scopes')
-      }).to.throw("unexpected token ' ' at position 4 valid tokens [:, (]")
+      }).to.throw("unexpected token ' ' at position { line: 1, column: 5, offset: 4 } valid tokens [:, (]")
       expect(() => {
         parser('feat( foo ) add support for scopes')
-      }).to.throw("unexpected token ' ' at position 11 valid tokens [:]")
+      }).to.throw("unexpected token ' ' at position { line: 1, column: 12, offset: 11 } valid tokens [:]")
     })
     it('throws error when closing ")" token is missing', () => {
       expect(() => {

--- a/test.js
+++ b/test.js
@@ -29,10 +29,10 @@ describe('<message>', () => {
     it('throws error when ":" token is missing', () => {
       expect(() => {
         parser('feat add support for scopes')
-      }).to.throw("unexpected token ' ' at position { line: 1, column: 5, offset: 4 } valid tokens [:, (]")
+      }).to.throw("unexpected token ' ' at position 1:5 valid tokens [:, (]")
       expect(() => {
         parser('feat( foo ) add support for scopes')
-      }).to.throw("unexpected token ' ' at position { line: 1, column: 12, offset: 11 } valid tokens [:]")
+      }).to.throw("unexpected token ' ' at position 1:12 valid tokens [:]")
     })
     it('throws error when closing ")" token is missing', () => {
       expect(() => {

--- a/test.js.snap
+++ b/test.js.snap
@@ -82,13 +82,13 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 39,
-                      "line": 1,
+                      "column": 16,
+                      "line": 2,
                       "offset": 38,
                     },
                     "start": Object {
-                      "column": 24,
-                      "line": 1,
+                      "column": 1,
+                      "line": 2,
                       "offset": 23,
                     },
                   },
@@ -98,13 +98,13 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 39,
-                  "line": 1,
+                  "column": 16,
+                  "line": 2,
                   "offset": 38,
                 },
                 "start": Object {
-                  "column": 24,
-                  "line": 1,
+                  "column": 1,
+                  "line": 2,
                   "offset": 23,
                 },
               },
@@ -115,13 +115,13 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 40,
-                      "line": 1,
+                      "column": 17,
+                      "line": 2,
                       "offset": 39,
                     },
                     "start": Object {
-                      "column": 39,
-                      "line": 1,
+                      "column": 16,
+                      "line": 2,
                       "offset": 38,
                     },
                   },
@@ -136,13 +136,13 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 64,
-                      "line": 1,
+                      "column": 41,
+                      "line": 2,
                       "offset": 63,
                     },
                     "start": Object {
-                      "column": 41,
-                      "line": 1,
+                      "column": 18,
+                      "line": 2,
                       "offset": 40,
                     },
                   },
@@ -152,13 +152,13 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 64,
-                  "line": 1,
+                  "column": 41,
+                  "line": 2,
                   "offset": 63,
                 },
                 "start": Object {
-                  "column": 41,
-                  "line": 1,
+                  "column": 18,
+                  "line": 2,
                   "offset": 40,
                 },
               },
@@ -167,13 +167,13 @@ Object {
           ],
           "position": Object {
             "end": Object {
-              "column": 64,
-              "line": 1,
+              "column": 41,
+              "line": 2,
               "offset": 63,
             },
             "start": Object {
-              "column": 24,
-              "line": 1,
+              "column": 1,
+              "line": 2,
               "offset": 23,
             },
           },
@@ -182,13 +182,13 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 64,
-          "line": 1,
+          "column": 41,
+          "line": 2,
           "offset": 63,
         },
         "start": Object {
-          "column": 24,
-          "line": 1,
+          "column": 1,
+          "line": 2,
           "offset": 23,
         },
       },
@@ -197,8 +197,8 @@ Object {
   ],
   "position": Object {
     "end": Object {
-      "column": 64,
-      "line": 1,
+      "column": 41,
+      "line": 2,
       "offset": 63,
     },
     "start": Object {
@@ -293,13 +293,13 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 37,
-                      "line": 1,
+                      "column": 4,
+                      "line": 2,
                       "offset": 36,
                     },
                     "start": Object {
-                      "column": 34,
-                      "line": 1,
+                      "column": 1,
+                      "line": 2,
                       "offset": 33,
                     },
                   },
@@ -309,13 +309,13 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 44,
-                      "line": 1,
+                      "column": 11,
+                      "line": 2,
                       "offset": 43,
                     },
                     "start": Object {
-                      "column": 38,
-                      "line": 1,
+                      "column": 5,
+                      "line": 2,
                       "offset": 37,
                     },
                   },
@@ -325,13 +325,13 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 45,
-                  "line": 1,
+                  "column": 12,
+                  "line": 2,
                   "offset": 44,
                 },
                 "start": Object {
-                  "column": 70,
-                  "line": 1,
+                  "column": 37,
+                  "line": 2,
                   "offset": 69,
                 },
               },
@@ -342,13 +342,13 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 46,
-                      "line": 1,
+                      "column": 13,
+                      "line": 2,
                       "offset": 45,
                     },
                     "start": Object {
-                      "column": 45,
-                      "line": 1,
+                      "column": 12,
+                      "line": 2,
                       "offset": 44,
                     },
                   },
@@ -363,13 +363,13 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 70,
-                      "line": 1,
+                      "column": 37,
+                      "line": 2,
                       "offset": 69,
                     },
                     "start": Object {
-                      "column": 47,
-                      "line": 1,
+                      "column": 14,
+                      "line": 2,
                       "offset": 46,
                     },
                   },
@@ -379,13 +379,13 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 70,
-                  "line": 1,
+                  "column": 37,
+                  "line": 2,
                   "offset": 69,
                 },
                 "start": Object {
-                  "column": 47,
-                  "line": 1,
+                  "column": 14,
+                  "line": 2,
                   "offset": 46,
                 },
               },
@@ -394,13 +394,13 @@ Object {
           ],
           "position": Object {
             "end": Object {
-              "column": 70,
-              "line": 1,
+              "column": 37,
+              "line": 2,
               "offset": 69,
             },
             "start": Object {
-              "column": 34,
-              "line": 1,
+              "column": 1,
+              "line": 2,
               "offset": 33,
             },
           },
@@ -409,13 +409,13 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 70,
-          "line": 1,
+          "column": 37,
+          "line": 2,
           "offset": 69,
         },
         "start": Object {
-          "column": 34,
-          "line": 1,
+          "column": 1,
+          "line": 2,
           "offset": 33,
         },
       },
@@ -424,8 +424,8 @@ Object {
   ],
   "position": Object {
     "end": Object {
-      "column": 70,
-      "line": 1,
+      "column": 37,
+      "line": 2,
       "offset": 69,
     },
     "start": Object {
@@ -520,13 +520,13 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 30,
-                      "line": 1,
+                      "column": 7,
+                      "line": 2,
                       "offset": 29,
                     },
                     "start": Object {
-                      "column": 24,
-                      "line": 1,
+                      "column": 1,
+                      "line": 2,
                       "offset": 23,
                     },
                   },
@@ -536,13 +536,13 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 30,
-                  "line": 1,
+                  "column": 7,
+                  "line": 2,
                   "offset": 29,
                 },
                 "start": Object {
-                  "column": 41,
-                  "line": 1,
+                  "column": 18,
+                  "line": 2,
                   "offset": 40,
                 },
               },
@@ -553,13 +553,13 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 31,
-                      "line": 1,
+                      "column": 8,
+                      "line": 2,
                       "offset": 30,
                     },
                     "start": Object {
-                      "column": 30,
-                      "line": 1,
+                      "column": 7,
+                      "line": 2,
                       "offset": 29,
                     },
                   },
@@ -574,13 +574,13 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 41,
-                      "line": 1,
+                      "column": 18,
+                      "line": 2,
                       "offset": 40,
                     },
                     "start": Object {
-                      "column": 32,
-                      "line": 1,
+                      "column": 9,
+                      "line": 2,
                       "offset": 31,
                     },
                   },
@@ -590,13 +590,13 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 41,
-                  "line": 1,
+                  "column": 18,
+                  "line": 2,
                   "offset": 40,
                 },
                 "start": Object {
-                  "column": 32,
-                  "line": 1,
+                  "column": 9,
+                  "line": 2,
                   "offset": 31,
                 },
               },
@@ -605,13 +605,13 @@ Object {
           ],
           "position": Object {
             "end": Object {
-              "column": 41,
-              "line": 1,
+              "column": 18,
+              "line": 2,
               "offset": 40,
             },
             "start": Object {
-              "column": 24,
-              "line": 1,
+              "column": 1,
+              "line": 2,
               "offset": 23,
             },
           },
@@ -620,13 +620,13 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 41,
-          "line": 1,
+          "column": 18,
+          "line": 2,
           "offset": 40,
         },
         "start": Object {
-          "column": 24,
-          "line": 1,
+          "column": 1,
+          "line": 2,
           "offset": 23,
         },
       },
@@ -635,8 +635,8 @@ Object {
   ],
   "position": Object {
     "end": Object {
-      "column": 41,
-      "line": 1,
+      "column": 18,
+      "line": 2,
       "offset": 40,
     },
     "start": Object {
@@ -731,13 +731,13 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 39,
-                      "line": 1,
+                      "column": 16,
+                      "line": 2,
                       "offset": 38,
                     },
                     "start": Object {
-                      "column": 24,
-                      "line": 1,
+                      "column": 1,
+                      "line": 2,
                       "offset": 23,
                     },
                   },
@@ -747,13 +747,13 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 39,
-                  "line": 1,
+                  "column": 16,
+                  "line": 2,
                   "offset": 38,
                 },
                 "start": Object {
-                  "column": 24,
-                  "line": 1,
+                  "column": 1,
+                  "line": 2,
                   "offset": 23,
                 },
               },
@@ -764,13 +764,13 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 40,
-                      "line": 1,
+                      "column": 17,
+                      "line": 2,
                       "offset": 39,
                     },
                     "start": Object {
-                      "column": 39,
-                      "line": 1,
+                      "column": 16,
+                      "line": 2,
                       "offset": 38,
                     },
                   },
@@ -785,13 +785,13 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 70,
-                      "line": 1,
+                      "column": 47,
+                      "line": 2,
                       "offset": 69,
                     },
                     "start": Object {
-                      "column": 41,
-                      "line": 1,
+                      "column": 18,
+                      "line": 2,
                       "offset": 40,
                     },
                   },
@@ -803,13 +803,13 @@ Object {
                     Object {
                       "position": Object {
                         "end": Object {
-                          "column": 102,
-                          "line": 1,
+                          "column": 32,
+                          "line": 3,
                           "offset": 101,
                         },
                         "start": Object {
-                          "column": 72,
-                          "line": 1,
+                          "column": 2,
+                          "line": 3,
                           "offset": 71,
                         },
                       },
@@ -819,13 +819,13 @@ Object {
                   ],
                   "position": Object {
                     "end": Object {
-                      "column": 102,
-                      "line": 1,
+                      "column": 32,
+                      "line": 3,
                       "offset": 101,
                     },
                     "start": Object {
-                      "column": 70,
-                      "line": 1,
+                      "column": 47,
+                      "line": 2,
                       "offset": 69,
                     },
                   },
@@ -836,13 +836,13 @@ Object {
                     Object {
                       "position": Object {
                         "end": Object {
-                          "column": 133,
-                          "line": 1,
+                          "column": 31,
+                          "line": 4,
                           "offset": 132,
                         },
                         "start": Object {
-                          "column": 104,
-                          "line": 1,
+                          "column": 2,
+                          "line": 4,
                           "offset": 103,
                         },
                       },
@@ -852,13 +852,13 @@ Object {
                   ],
                   "position": Object {
                     "end": Object {
-                      "column": 133,
-                      "line": 1,
+                      "column": 31,
+                      "line": 4,
                       "offset": 132,
                     },
                     "start": Object {
-                      "column": 102,
-                      "line": 1,
+                      "column": 32,
+                      "line": 3,
                       "offset": 101,
                     },
                   },
@@ -867,13 +867,13 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 133,
-                  "line": 1,
+                  "column": 31,
+                  "line": 4,
                   "offset": 132,
                 },
                 "start": Object {
-                  "column": 41,
-                  "line": 1,
+                  "column": 18,
+                  "line": 2,
                   "offset": 40,
                 },
               },
@@ -882,13 +882,13 @@ Object {
           ],
           "position": Object {
             "end": Object {
-              "column": 133,
-              "line": 1,
+              "column": 31,
+              "line": 4,
               "offset": 132,
             },
             "start": Object {
-              "column": 24,
-              "line": 1,
+              "column": 1,
+              "line": 2,
               "offset": 23,
             },
           },
@@ -897,13 +897,13 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 133,
-          "line": 1,
+          "column": 31,
+          "line": 4,
           "offset": 132,
         },
         "start": Object {
-          "column": 24,
-          "line": 1,
+          "column": 1,
+          "line": 2,
           "offset": 23,
         },
       },
@@ -912,8 +912,8 @@ Object {
   ],
   "position": Object {
     "end": Object {
-      "column": 133,
-      "line": 1,
+      "column": 31,
+      "line": 4,
       "offset": 132,
     },
     "start": Object {

--- a/test.js.snap
+++ b/test.js.snap
@@ -45,12 +45,12 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 22,
+              "column": 23,
               "line": 1,
               "offset": 22,
             },
             "start": Object {
-              "column": 5,
+              "column": 6,
               "line": 1,
               "offset": 5,
             },
@@ -61,7 +61,7 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 22,
+          "column": 23,
           "line": 1,
           "offset": 22,
         },
@@ -82,12 +82,12 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 38,
+                      "column": 39,
                       "line": 1,
                       "offset": 38,
                     },
                     "start": Object {
-                      "column": 23,
+                      "column": 24,
                       "line": 1,
                       "offset": 23,
                     },
@@ -98,12 +98,12 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 38,
+                  "column": 39,
                   "line": 1,
                   "offset": 38,
                 },
                 "start": Object {
-                  "column": 23,
+                  "column": 24,
                   "line": 1,
                   "offset": 23,
                 },
@@ -115,12 +115,12 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 39,
+                      "column": 40,
                       "line": 1,
                       "offset": 39,
                     },
                     "start": Object {
-                      "column": 38,
+                      "column": 39,
                       "line": 1,
                       "offset": 38,
                     },
@@ -136,12 +136,12 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 62,
+                      "column": 64,
                       "line": 1,
                       "offset": 63,
                     },
                     "start": Object {
-                      "column": 39,
+                      "column": 41,
                       "line": 1,
                       "offset": 40,
                     },
@@ -152,12 +152,12 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 62,
+                  "column": 64,
                   "line": 1,
                   "offset": 63,
                 },
                 "start": Object {
-                  "column": 39,
+                  "column": 41,
                   "line": 1,
                   "offset": 40,
                 },
@@ -167,12 +167,12 @@ Object {
           ],
           "position": Object {
             "end": Object {
-              "column": 62,
+              "column": 64,
               "line": 1,
               "offset": 63,
             },
             "start": Object {
-              "column": 23,
+              "column": 24,
               "line": 1,
               "offset": 23,
             },
@@ -182,12 +182,12 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 62,
+          "column": 64,
           "line": 1,
           "offset": 63,
         },
         "start": Object {
-          "column": 23,
+          "column": 24,
           "line": 1,
           "offset": 23,
         },
@@ -197,7 +197,7 @@ Object {
   ],
   "position": Object {
     "end": Object {
-      "column": 62,
+      "column": 64,
       "line": 1,
       "offset": 63,
     },
@@ -256,12 +256,12 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 32,
+              "column": 33,
               "line": 1,
               "offset": 32,
             },
             "start": Object {
-              "column": 7,
+              "column": 8,
               "line": 1,
               "offset": 7,
             },
@@ -272,7 +272,7 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 32,
+          "column": 33,
           "line": 1,
           "offset": 32,
         },
@@ -293,12 +293,12 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 36,
+                      "column": 37,
                       "line": 1,
                       "offset": 36,
                     },
                     "start": Object {
-                      "column": 33,
+                      "column": 34,
                       "line": 1,
                       "offset": 33,
                     },
@@ -309,12 +309,12 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 43,
+                      "column": 44,
                       "line": 1,
                       "offset": 43,
                     },
                     "start": Object {
-                      "column": 37,
+                      "column": 38,
                       "line": 1,
                       "offset": 37,
                     },
@@ -325,12 +325,12 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 44,
+                  "column": 45,
                   "line": 1,
                   "offset": 44,
                 },
                 "start": Object {
-                  "column": 68,
+                  "column": 70,
                   "line": 1,
                   "offset": 69,
                 },
@@ -342,12 +342,12 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 45,
+                      "column": 46,
                       "line": 1,
                       "offset": 45,
                     },
                     "start": Object {
-                      "column": 44,
+                      "column": 45,
                       "line": 1,
                       "offset": 44,
                     },
@@ -363,12 +363,12 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 68,
+                      "column": 70,
                       "line": 1,
                       "offset": 69,
                     },
                     "start": Object {
-                      "column": 45,
+                      "column": 47,
                       "line": 1,
                       "offset": 46,
                     },
@@ -379,12 +379,12 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 68,
+                  "column": 70,
                   "line": 1,
                   "offset": 69,
                 },
                 "start": Object {
-                  "column": 45,
+                  "column": 47,
                   "line": 1,
                   "offset": 46,
                 },
@@ -394,12 +394,12 @@ Object {
           ],
           "position": Object {
             "end": Object {
-              "column": 68,
+              "column": 70,
               "line": 1,
               "offset": 69,
             },
             "start": Object {
-              "column": 33,
+              "column": 34,
               "line": 1,
               "offset": 33,
             },
@@ -409,12 +409,12 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 68,
+          "column": 70,
           "line": 1,
           "offset": 69,
         },
         "start": Object {
-          "column": 33,
+          "column": 34,
           "line": 1,
           "offset": 33,
         },
@@ -424,7 +424,7 @@ Object {
   ],
   "position": Object {
     "end": Object {
-      "column": 68,
+      "column": 70,
       "line": 1,
       "offset": 69,
     },
@@ -483,12 +483,12 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 22,
+              "column": 23,
               "line": 1,
               "offset": 22,
             },
             "start": Object {
-              "column": 5,
+              "column": 6,
               "line": 1,
               "offset": 5,
             },
@@ -499,7 +499,7 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 22,
+          "column": 23,
           "line": 1,
           "offset": 22,
         },
@@ -520,12 +520,12 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 29,
+                      "column": 30,
                       "line": 1,
                       "offset": 29,
                     },
                     "start": Object {
-                      "column": 23,
+                      "column": 24,
                       "line": 1,
                       "offset": 23,
                     },
@@ -536,12 +536,12 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 29,
+                  "column": 30,
                   "line": 1,
                   "offset": 29,
                 },
                 "start": Object {
-                  "column": 39,
+                  "column": 41,
                   "line": 1,
                   "offset": 40,
                 },
@@ -553,12 +553,12 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 30,
+                      "column": 31,
                       "line": 1,
                       "offset": 30,
                     },
                     "start": Object {
-                      "column": 29,
+                      "column": 30,
                       "line": 1,
                       "offset": 29,
                     },
@@ -574,12 +574,12 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 39,
+                      "column": 41,
                       "line": 1,
                       "offset": 40,
                     },
                     "start": Object {
-                      "column": 30,
+                      "column": 32,
                       "line": 1,
                       "offset": 31,
                     },
@@ -590,12 +590,12 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 39,
+                  "column": 41,
                   "line": 1,
                   "offset": 40,
                 },
                 "start": Object {
-                  "column": 30,
+                  "column": 32,
                   "line": 1,
                   "offset": 31,
                 },
@@ -605,12 +605,12 @@ Object {
           ],
           "position": Object {
             "end": Object {
-              "column": 39,
+              "column": 41,
               "line": 1,
               "offset": 40,
             },
             "start": Object {
-              "column": 23,
+              "column": 24,
               "line": 1,
               "offset": 23,
             },
@@ -620,12 +620,12 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 39,
+          "column": 41,
           "line": 1,
           "offset": 40,
         },
         "start": Object {
-          "column": 23,
+          "column": 24,
           "line": 1,
           "offset": 23,
         },
@@ -635,7 +635,7 @@ Object {
   ],
   "position": Object {
     "end": Object {
-      "column": 39,
+      "column": 41,
       "line": 1,
       "offset": 40,
     },
@@ -694,12 +694,12 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 22,
+              "column": 23,
               "line": 1,
               "offset": 22,
             },
             "start": Object {
-              "column": 5,
+              "column": 6,
               "line": 1,
               "offset": 5,
             },
@@ -710,7 +710,7 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 22,
+          "column": 23,
           "line": 1,
           "offset": 22,
         },
@@ -731,12 +731,12 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 38,
+                      "column": 39,
                       "line": 1,
                       "offset": 38,
                     },
                     "start": Object {
-                      "column": 23,
+                      "column": 24,
                       "line": 1,
                       "offset": 23,
                     },
@@ -747,12 +747,12 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 38,
+                  "column": 39,
                   "line": 1,
                   "offset": 38,
                 },
                 "start": Object {
-                  "column": 23,
+                  "column": 24,
                   "line": 1,
                   "offset": 23,
                 },
@@ -764,12 +764,12 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 39,
+                      "column": 40,
                       "line": 1,
                       "offset": 39,
                     },
                     "start": Object {
-                      "column": 38,
+                      "column": 39,
                       "line": 1,
                       "offset": 38,
                     },
@@ -785,12 +785,12 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
-                      "column": 68,
+                      "column": 70,
                       "line": 1,
                       "offset": 69,
                     },
                     "start": Object {
-                      "column": 39,
+                      "column": 41,
                       "line": 1,
                       "offset": 40,
                     },
@@ -803,12 +803,12 @@ Object {
                     Object {
                       "position": Object {
                         "end": Object {
-                          "column": 100,
+                          "column": 102,
                           "line": 1,
                           "offset": 101,
                         },
                         "start": Object {
-                          "column": 70,
+                          "column": 72,
                           "line": 1,
                           "offset": 71,
                         },
@@ -819,12 +819,12 @@ Object {
                   ],
                   "position": Object {
                     "end": Object {
-                      "column": 100,
+                      "column": 102,
                       "line": 1,
                       "offset": 101,
                     },
                     "start": Object {
-                      "column": 68,
+                      "column": 70,
                       "line": 1,
                       "offset": 69,
                     },
@@ -836,12 +836,12 @@ Object {
                     Object {
                       "position": Object {
                         "end": Object {
-                          "column": 131,
+                          "column": 133,
                           "line": 1,
                           "offset": 132,
                         },
                         "start": Object {
-                          "column": 102,
+                          "column": 104,
                           "line": 1,
                           "offset": 103,
                         },
@@ -852,12 +852,12 @@ Object {
                   ],
                   "position": Object {
                     "end": Object {
-                      "column": 131,
+                      "column": 133,
                       "line": 1,
                       "offset": 132,
                     },
                     "start": Object {
-                      "column": 100,
+                      "column": 102,
                       "line": 1,
                       "offset": 101,
                     },
@@ -867,12 +867,12 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 131,
+                  "column": 133,
                   "line": 1,
                   "offset": 132,
                 },
                 "start": Object {
-                  "column": 39,
+                  "column": 41,
                   "line": 1,
                   "offset": 40,
                 },
@@ -882,12 +882,12 @@ Object {
           ],
           "position": Object {
             "end": Object {
-              "column": 131,
+              "column": 133,
               "line": 1,
               "offset": 132,
             },
             "start": Object {
-              "column": 23,
+              "column": 24,
               "line": 1,
               "offset": 23,
             },
@@ -897,12 +897,12 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 131,
+          "column": 133,
           "line": 1,
           "offset": 132,
         },
         "start": Object {
-          "column": 23,
+          "column": 24,
           "line": 1,
           "offset": 23,
         },
@@ -912,7 +912,7 @@ Object {
   ],
   "position": Object {
     "end": Object {
-      "column": 131,
+      "column": 133,
       "line": 1,
       "offset": 132,
     },
@@ -950,10 +950,34 @@ Object {
         Object {
           "children": Array [
             Object {
+              "position": Object {
+                "end": Object {
+                  "column": 6,
+                  "line": 1,
+                  "offset": 5,
+                },
+                "start": Object {
+                  "column": 5,
+                  "line": 1,
+                  "offset": 4,
+                },
+              },
               "type": "breaking-change",
               "value": "!",
             },
             Object {
+              "position": Object {
+                "end": Object {
+                  "column": 7,
+                  "line": 1,
+                  "offset": 6,
+                },
+                "start": Object {
+                  "column": 6,
+                  "line": 1,
+                  "offset": 5,
+                },
+              },
               "type": "separator",
               "value": ":",
             },
@@ -963,12 +987,12 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 29,
+              "column": 30,
               "line": 1,
               "offset": 29,
             },
             "start": Object {
-              "column": 7,
+              "column": 8,
               "line": 1,
               "offset": 7,
             },
@@ -979,7 +1003,7 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 29,
+          "column": 30,
           "line": 1,
           "offset": 29,
         },
@@ -992,6 +1016,18 @@ Object {
       "type": "summary",
     },
   ],
+  "position": Object {
+    "end": Object {
+      "column": 30,
+      "line": 1,
+      "offset": 29,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
   "type": "message",
 }
 `;
@@ -1036,10 +1072,34 @@ Object {
         Object {
           "children": Array [
             Object {
+              "position": Object {
+                "end": Object {
+                  "column": 19,
+                  "line": 1,
+                  "offset": 18,
+                },
+                "start": Object {
+                  "column": 18,
+                  "line": 1,
+                  "offset": 17,
+                },
+              },
               "type": "breaking-change",
               "value": "!",
             },
             Object {
+              "position": Object {
+                "end": Object {
+                  "column": 20,
+                  "line": 1,
+                  "offset": 19,
+                },
+                "start": Object {
+                  "column": 19,
+                  "line": 1,
+                  "offset": 18,
+                },
+              },
               "type": "separator",
               "value": ":",
             },
@@ -1049,12 +1109,12 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 42,
+              "column": 43,
               "line": 1,
               "offset": 42,
             },
             "start": Object {
-              "column": 20,
+              "column": 21,
               "line": 1,
               "offset": 20,
             },
@@ -1065,7 +1125,7 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 42,
+          "column": 43,
           "line": 1,
           "offset": 42,
         },
@@ -1078,6 +1138,18 @@ Object {
       "type": "summary",
     },
   ],
+  "position": Object {
+    "end": Object {
+      "column": 43,
+      "line": 1,
+      "offset": 42,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
   "type": "message",
 }
 `;
@@ -1127,12 +1199,12 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 23,
+              "column": 24,
               "line": 1,
               "offset": 23,
             },
             "start": Object {
-              "column": 5,
+              "column": 6,
               "line": 1,
               "offset": 5,
             },
@@ -1143,7 +1215,7 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 23,
+          "column": 24,
           "line": 1,
           "offset": 23,
         },
@@ -1156,6 +1228,18 @@ Object {
       "type": "summary",
     },
   ],
+  "position": Object {
+    "end": Object {
+      "column": 24,
+      "line": 1,
+      "offset": 23,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
   "type": "message",
 }
 `;
@@ -1221,12 +1305,12 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 36,
+              "column": 37,
               "line": 1,
               "offset": 36,
             },
             "start": Object {
-              "column": 14,
+              "column": 15,
               "line": 1,
               "offset": 14,
             },
@@ -1237,7 +1321,7 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 36,
+          "column": 37,
           "line": 1,
           "offset": 36,
         },
@@ -1250,6 +1334,18 @@ Object {
       "type": "summary",
     },
   ],
+  "position": Object {
+    "end": Object {
+      "column": 37,
+      "line": 1,
+      "offset": 36,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
   "type": "message",
 }
 `;

--- a/test.js.snap
+++ b/test.js.snap
@@ -6,12 +6,36 @@ Object {
     Object {
       "children": Array [
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 4,
+              "line": 1,
+              "offset": 3,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
           "type": "type",
           "value": "fix",
         },
         Object {
           "children": Array [
             Object {
+              "position": Object {
+                "end": Object {
+                  "column": 5,
+                  "line": 1,
+                  "offset": 4,
+                },
+                "start": Object {
+                  "column": 4,
+                  "line": 1,
+                  "offset": 3,
+                },
+              },
               "type": "separator",
               "value": ":",
             },
@@ -19,10 +43,34 @@ Object {
           "type": "summary-sep",
         },
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 22,
+              "line": 1,
+              "offset": 22,
+            },
+            "start": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 5,
+            },
+          },
           "type": "text",
           "value": "address major bug",
         },
       ],
+      "position": Object {
+        "end": Object {
+          "column": 22,
+          "line": 1,
+          "offset": 22,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
       "type": "summary",
     },
     Object {
@@ -32,15 +80,51 @@ Object {
             Object {
               "children": Array [
                 Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 38,
+                      "line": 1,
+                      "offset": 38,
+                    },
+                    "start": Object {
+                      "column": 23,
+                      "line": 1,
+                      "offset": 23,
+                    },
+                  },
                   "type": "breaking-change",
                   "value": "BREAKING CHANGE",
                 },
               ],
+              "position": Object {
+                "end": Object {
+                  "column": 38,
+                  "line": 1,
+                  "offset": 38,
+                },
+                "start": Object {
+                  "column": 23,
+                  "line": 1,
+                  "offset": 23,
+                },
+              },
               "type": "token",
             },
             Object {
               "children": Array [
                 Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 39,
+                      "line": 1,
+                      "offset": 39,
+                    },
+                    "start": Object {
+                      "column": 38,
+                      "line": 1,
+                      "offset": 38,
+                    },
+                  },
                   "type": "separator",
                   "value": ":",
                 },
@@ -50,19 +134,79 @@ Object {
             Object {
               "children": Array [
                 Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 62,
+                      "line": 1,
+                      "offset": 63,
+                    },
+                    "start": Object {
+                      "column": 39,
+                      "line": 1,
+                      "offset": 40,
+                    },
+                  },
                   "type": "text",
                   "value": "this change is breaking",
                 },
               ],
+              "position": Object {
+                "end": Object {
+                  "column": 62,
+                  "line": 1,
+                  "offset": 63,
+                },
+                "start": Object {
+                  "column": 39,
+                  "line": 1,
+                  "offset": 40,
+                },
+              },
               "type": "value",
             },
           ],
+          "position": Object {
+            "end": Object {
+              "column": 62,
+              "line": 1,
+              "offset": 63,
+            },
+            "start": Object {
+              "column": 23,
+              "line": 1,
+              "offset": 23,
+            },
+          },
           "type": "footer",
         },
       ],
+      "position": Object {
+        "end": Object {
+          "column": 62,
+          "line": 1,
+          "offset": 63,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 1,
+          "offset": 23,
+        },
+      },
       "type": "body-footer",
     },
   ],
+  "position": Object {
+    "end": Object {
+      "column": 62,
+      "line": 1,
+      "offset": 63,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
   "type": "message",
 }
 `;
@@ -73,12 +217,36 @@ Object {
     Object {
       "children": Array [
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
           "type": "type",
           "value": "chore",
         },
         Object {
           "children": Array [
             Object {
+              "position": Object {
+                "end": Object {
+                  "column": 7,
+                  "line": 1,
+                  "offset": 6,
+                },
+                "start": Object {
+                  "column": 6,
+                  "line": 1,
+                  "offset": 5,
+                },
+              },
               "type": "separator",
               "value": ":",
             },
@@ -86,10 +254,34 @@ Object {
           "type": "summary-sep",
         },
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 32,
+              "line": 1,
+              "offset": 32,
+            },
+            "start": Object {
+              "column": 7,
+              "line": 1,
+              "offset": 7,
+            },
+          },
           "type": "text",
           "value": "contains multiple commits",
         },
       ],
+      "position": Object {
+        "end": Object {
+          "column": 32,
+          "line": 1,
+          "offset": 32,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
       "type": "summary",
     },
     Object {
@@ -99,19 +291,67 @@ Object {
             Object {
               "children": Array [
                 Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 36,
+                      "line": 1,
+                      "offset": 36,
+                    },
+                    "start": Object {
+                      "column": 33,
+                      "line": 1,
+                      "offset": 33,
+                    },
+                  },
                   "type": "type",
                   "value": "fix",
                 },
                 Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 43,
+                      "line": 1,
+                      "offset": 43,
+                    },
+                    "start": Object {
+                      "column": 37,
+                      "line": 1,
+                      "offset": 37,
+                    },
+                  },
                   "type": "scope",
                   "value": "parser",
                 },
               ],
+              "position": Object {
+                "end": Object {
+                  "column": 44,
+                  "line": 1,
+                  "offset": 44,
+                },
+                "start": Object {
+                  "column": 68,
+                  "line": 1,
+                  "offset": 69,
+                },
+              },
               "type": "token",
             },
             Object {
               "children": Array [
                 Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 45,
+                      "line": 1,
+                      "offset": 45,
+                    },
+                    "start": Object {
+                      "column": 44,
+                      "line": 1,
+                      "offset": 44,
+                    },
+                  },
                   "type": "separator",
                   "value": ":",
                 },
@@ -121,19 +361,79 @@ Object {
             Object {
               "children": Array [
                 Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 68,
+                      "line": 1,
+                      "offset": 69,
+                    },
+                    "start": Object {
+                      "column": 45,
+                      "line": 1,
+                      "offset": 46,
+                    },
+                  },
                   "type": "text",
                   "value": "address bug with parser",
                 },
               ],
+              "position": Object {
+                "end": Object {
+                  "column": 68,
+                  "line": 1,
+                  "offset": 69,
+                },
+                "start": Object {
+                  "column": 45,
+                  "line": 1,
+                  "offset": 46,
+                },
+              },
               "type": "value",
             },
           ],
+          "position": Object {
+            "end": Object {
+              "column": 68,
+              "line": 1,
+              "offset": 69,
+            },
+            "start": Object {
+              "column": 33,
+              "line": 1,
+              "offset": 33,
+            },
+          },
           "type": "footer",
         },
       ],
+      "position": Object {
+        "end": Object {
+          "column": 68,
+          "line": 1,
+          "offset": 69,
+        },
+        "start": Object {
+          "column": 33,
+          "line": 1,
+          "offset": 33,
+        },
+      },
       "type": "body-footer",
     },
   ],
+  "position": Object {
+    "end": Object {
+      "column": 68,
+      "line": 1,
+      "offset": 69,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
   "type": "message",
 }
 `;
@@ -144,12 +444,36 @@ Object {
     Object {
       "children": Array [
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 4,
+              "line": 1,
+              "offset": 3,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
           "type": "type",
           "value": "fix",
         },
         Object {
           "children": Array [
             Object {
+              "position": Object {
+                "end": Object {
+                  "column": 5,
+                  "line": 1,
+                  "offset": 4,
+                },
+                "start": Object {
+                  "column": 4,
+                  "line": 1,
+                  "offset": 3,
+                },
+              },
               "type": "separator",
               "value": ":",
             },
@@ -157,10 +481,34 @@ Object {
           "type": "summary-sep",
         },
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 22,
+              "line": 1,
+              "offset": 22,
+            },
+            "start": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 5,
+            },
+          },
           "type": "text",
           "value": "address major bug",
         },
       ],
+      "position": Object {
+        "end": Object {
+          "column": 22,
+          "line": 1,
+          "offset": 22,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
       "type": "summary",
     },
     Object {
@@ -170,15 +518,51 @@ Object {
             Object {
               "children": Array [
                 Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 29,
+                      "line": 1,
+                      "offset": 29,
+                    },
+                    "start": Object {
+                      "column": 23,
+                      "line": 1,
+                      "offset": 23,
+                    },
+                  },
                   "type": "type",
                   "value": "Author",
                 },
               ],
+              "position": Object {
+                "end": Object {
+                  "column": 29,
+                  "line": 1,
+                  "offset": 29,
+                },
+                "start": Object {
+                  "column": 39,
+                  "line": 1,
+                  "offset": 40,
+                },
+              },
               "type": "token",
             },
             Object {
               "children": Array [
                 Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 30,
+                      "line": 1,
+                      "offset": 30,
+                    },
+                    "start": Object {
+                      "column": 29,
+                      "line": 1,
+                      "offset": 29,
+                    },
+                  },
                   "type": "separator",
                   "value": ":",
                 },
@@ -188,19 +572,79 @@ Object {
             Object {
               "children": Array [
                 Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 39,
+                      "line": 1,
+                      "offset": 40,
+                    },
+                    "start": Object {
+                      "column": 30,
+                      "line": 1,
+                      "offset": 31,
+                    },
+                  },
                   "type": "text",
                   "value": "@byCedric",
                 },
               ],
+              "position": Object {
+                "end": Object {
+                  "column": 39,
+                  "line": 1,
+                  "offset": 40,
+                },
+                "start": Object {
+                  "column": 30,
+                  "line": 1,
+                  "offset": 31,
+                },
+              },
               "type": "value",
             },
           ],
+          "position": Object {
+            "end": Object {
+              "column": 39,
+              "line": 1,
+              "offset": 40,
+            },
+            "start": Object {
+              "column": 23,
+              "line": 1,
+              "offset": 23,
+            },
+          },
           "type": "footer",
         },
       ],
+      "position": Object {
+        "end": Object {
+          "column": 39,
+          "line": 1,
+          "offset": 40,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 1,
+          "offset": 23,
+        },
+      },
       "type": "body-footer",
     },
   ],
+  "position": Object {
+    "end": Object {
+      "column": 39,
+      "line": 1,
+      "offset": 40,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
   "type": "message",
 }
 `;
@@ -211,12 +655,36 @@ Object {
     Object {
       "children": Array [
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 4,
+              "line": 1,
+              "offset": 3,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
           "type": "type",
           "value": "fix",
         },
         Object {
           "children": Array [
             Object {
+              "position": Object {
+                "end": Object {
+                  "column": 5,
+                  "line": 1,
+                  "offset": 4,
+                },
+                "start": Object {
+                  "column": 4,
+                  "line": 1,
+                  "offset": 3,
+                },
+              },
               "type": "separator",
               "value": ":",
             },
@@ -224,10 +692,34 @@ Object {
           "type": "summary-sep",
         },
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 22,
+              "line": 1,
+              "offset": 22,
+            },
+            "start": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 5,
+            },
+          },
           "type": "text",
           "value": "address major bug",
         },
       ],
+      "position": Object {
+        "end": Object {
+          "column": 22,
+          "line": 1,
+          "offset": 22,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
       "type": "summary",
     },
     Object {
@@ -237,15 +729,51 @@ Object {
             Object {
               "children": Array [
                 Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 38,
+                      "line": 1,
+                      "offset": 38,
+                    },
+                    "start": Object {
+                      "column": 23,
+                      "line": 1,
+                      "offset": 23,
+                    },
+                  },
                   "type": "breaking-change",
                   "value": "BREAKING CHANGE",
                 },
               ],
+              "position": Object {
+                "end": Object {
+                  "column": 38,
+                  "line": 1,
+                  "offset": 38,
+                },
+                "start": Object {
+                  "column": 23,
+                  "line": 1,
+                  "offset": 23,
+                },
+              },
               "type": "token",
             },
             Object {
               "children": Array [
                 Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 39,
+                      "line": 1,
+                      "offset": 39,
+                    },
+                    "start": Object {
+                      "column": 38,
+                      "line": 1,
+                      "offset": 38,
+                    },
+                  },
                   "type": "separator",
                   "value": ":",
                 },
@@ -255,37 +783,145 @@ Object {
             Object {
               "children": Array [
                 Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 68,
+                      "line": 1,
+                      "offset": 69,
+                    },
+                    "start": Object {
+                      "column": 39,
+                      "line": 1,
+                      "offset": 40,
+                    },
+                  },
                   "type": "text",
                   "value": "first line of breaking change",
                 },
                 Object {
                   "children": Array [
                     Object {
+                      "position": Object {
+                        "end": Object {
+                          "column": 100,
+                          "line": 1,
+                          "offset": 101,
+                        },
+                        "start": Object {
+                          "column": 70,
+                          "line": 1,
+                          "offset": 71,
+                        },
+                      },
                       "type": "text",
                       "value": "second line of breaking change",
                     },
                   ],
+                  "position": Object {
+                    "end": Object {
+                      "column": 100,
+                      "line": 1,
+                      "offset": 101,
+                    },
+                    "start": Object {
+                      "column": 68,
+                      "line": 1,
+                      "offset": 69,
+                    },
+                  },
                   "type": "continuation",
                 },
                 Object {
                   "children": Array [
                     Object {
+                      "position": Object {
+                        "end": Object {
+                          "column": 131,
+                          "line": 1,
+                          "offset": 132,
+                        },
+                        "start": Object {
+                          "column": 102,
+                          "line": 1,
+                          "offset": 103,
+                        },
+                      },
                       "type": "text",
                       "value": "third line of breaking change",
                     },
                   ],
+                  "position": Object {
+                    "end": Object {
+                      "column": 131,
+                      "line": 1,
+                      "offset": 132,
+                    },
+                    "start": Object {
+                      "column": 100,
+                      "line": 1,
+                      "offset": 101,
+                    },
+                  },
                   "type": "continuation",
                 },
               ],
+              "position": Object {
+                "end": Object {
+                  "column": 131,
+                  "line": 1,
+                  "offset": 132,
+                },
+                "start": Object {
+                  "column": 39,
+                  "line": 1,
+                  "offset": 40,
+                },
+              },
               "type": "value",
             },
           ],
+          "position": Object {
+            "end": Object {
+              "column": 131,
+              "line": 1,
+              "offset": 132,
+            },
+            "start": Object {
+              "column": 23,
+              "line": 1,
+              "offset": 23,
+            },
+          },
           "type": "footer",
         },
       ],
+      "position": Object {
+        "end": Object {
+          "column": 131,
+          "line": 1,
+          "offset": 132,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 1,
+          "offset": 23,
+        },
+      },
       "type": "body-footer",
     },
   ],
+  "position": Object {
+    "end": Object {
+      "column": 131,
+      "line": 1,
+      "offset": 132,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
   "type": "message",
 }
 `;
@@ -296,6 +932,18 @@ Object {
     Object {
       "children": Array [
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
           "type": "type",
           "value": "feat",
         },
@@ -313,10 +961,34 @@ Object {
           "type": "summary-sep",
         },
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 29,
+              "line": 1,
+              "offset": 29,
+            },
+            "start": Object {
+              "column": 7,
+              "line": 1,
+              "offset": 7,
+            },
+          },
           "type": "text",
           "value": "add support for scopes",
         },
       ],
+      "position": Object {
+        "end": Object {
+          "column": 29,
+          "line": 1,
+          "offset": 29,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
       "type": "summary",
     },
   ],
@@ -330,10 +1002,34 @@ Object {
     Object {
       "children": Array [
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
           "type": "type",
           "value": "feat",
         },
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 17,
+              "line": 1,
+              "offset": 16,
+            },
+            "start": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+          },
           "type": "scope",
           "value": "http parser",
         },
@@ -351,10 +1047,34 @@ Object {
           "type": "summary-sep",
         },
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 42,
+              "line": 1,
+              "offset": 42,
+            },
+            "start": Object {
+              "column": 20,
+              "line": 1,
+              "offset": 20,
+            },
+          },
           "type": "text",
           "value": "add support for scopes",
         },
       ],
+      "position": Object {
+        "end": Object {
+          "column": 42,
+          "line": 1,
+          "offset": 42,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
       "type": "summary",
     },
   ],
@@ -368,12 +1088,36 @@ Object {
     Object {
       "children": Array [
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 4,
+              "line": 1,
+              "offset": 3,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
           "type": "type",
           "value": "fix",
         },
         Object {
           "children": Array [
             Object {
+              "position": Object {
+                "end": Object {
+                  "column": 5,
+                  "line": 1,
+                  "offset": 4,
+                },
+                "start": Object {
+                  "column": 4,
+                  "line": 1,
+                  "offset": 3,
+                },
+              },
               "type": "separator",
               "value": ":",
             },
@@ -381,10 +1125,34 @@ Object {
           "type": "summary-sep",
         },
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 23,
+              "line": 1,
+              "offset": 23,
+            },
+            "start": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 5,
+            },
+          },
           "type": "text",
           "value": "a really weird bug",
         },
       ],
+      "position": Object {
+        "end": Object {
+          "column": 23,
+          "line": 1,
+          "offset": 23,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
       "type": "summary",
     },
   ],
@@ -398,16 +1166,52 @@ Object {
     Object {
       "children": Array [
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
           "type": "type",
           "value": "feat",
         },
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 12,
+              "line": 1,
+              "offset": 11,
+            },
+            "start": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+          },
           "type": "scope",
           "value": "parser",
         },
         Object {
           "children": Array [
             Object {
+              "position": Object {
+                "end": Object {
+                  "column": 14,
+                  "line": 1,
+                  "offset": 13,
+                },
+                "start": Object {
+                  "column": 13,
+                  "line": 1,
+                  "offset": 12,
+                },
+              },
               "type": "separator",
               "value": ":",
             },
@@ -415,10 +1219,34 @@ Object {
           "type": "summary-sep",
         },
         Object {
+          "position": Object {
+            "end": Object {
+              "column": 36,
+              "line": 1,
+              "offset": 36,
+            },
+            "start": Object {
+              "column": 14,
+              "line": 1,
+              "offset": 14,
+            },
+          },
           "type": "text",
           "value": "add support for scopes",
         },
       ],
+      "position": Object {
+        "end": Object {
+          "column": 36,
+          "line": 1,
+          "offset": 36,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
       "type": "summary",
     },
   ],


### PR DESCRIPTION
Fixes #3 

This adds the start and end position to the nodes.

- I updated `scanner.position` to return [valid unist `Point` objects](https://github.com/syntax-tree/unist#point), these are returned as copy to avoid the positions being changed later on.
- Also updated the tokenizers to fetch the `start` and `end` positions and include them in the parsed nodes.
- It's a breaking change because this replaces our original `scanner.pos` offset with the offset within the point (`scanner.pos.offset`)

I think we could do some refactoring. It's a bit repetitive to create 2 points and the node. Maybe something like `scanner.node` could help creating the node with start position. Or even [something like this](https://github.com/micromark/micromark/blob/ac44b027357e36694efd2c59babba1b89515e73c/lib/tokenize/code-text.mjs#L132-L134):

```
scanner.enter('some-node')
scanner.consume() // or anything else it needs to consume
const node = scanner.exit('some-node')
```