### PR TITLE
feat(grammar): ran grammar through linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ parser('feat(parser): add support for scopes')
 This parsing library is based on the following grammar. An effort will be made
 to keep this in sync with the written specification on conventionalcommits.org.
 
-```bnf
-# See: https://tools.ietf.org/html/rfc3629#section-4
-<UTF8-octets>  ::= 1*<UTF8-char>
+```ebnf
+/* See: https://tools.ietf.org/html/rfc3629#section-4 */
+<UTF8-char>     ::= "Placeholder for UTF-8 grammar"
+<UTF8-octets>   ::= <UTF8-char>+
+
 <CR>           ::= "0x000D"
 <LF>           ::= "0x000A"
 <newline>      ::= <CR>? <LF>
@@ -30,32 +32,34 @@ to keep this in sync with the written specification on conventionalcommits.org.
 <FF>           ::= "U+000C"
 <SP>           ::= "U+0020"
 <NBSP>         ::= "U+00A0"
-# See: https://www.ecma-international.org/ecma-262/11.0/index.html#sec-white-space
-<USP>          ::= "Any other Unicode “Space_Separator” code point"
+/* See: https://www.ecma-international.org/ecma-262/11.0/index.html#sec-white-space */
+<USP>          ::= "Any other Unicode 'Space_Separator' code point"
+/* Any non-newline whitespace: */
 <whitespace>   ::= <ZWNBSP> | <TAB> | <VT> | <FF> | <SP> | <NBSP> | <USP>
 
 <message>      ::= <summary> <newline> <body-footer>
-                |  <summary>
+               |  <summary>
 
-<summary>      ::= <type> "(" <scope> ")" <summary-sep> <text>
-                |  <type> <summary-sep> <text>
-<type>         ::= 1*<any UTF8-octets except newline or parens or ":" or "!:" or whitespace>
-<scope>        ::= 1*<any UTF8-octets except newline or parens>
-<text>         ::= 1*<any UTF8-octets except newline>
-<summary-sep>  ::= "!"? ":" *<whitespace>
+<summary>      ::= <type> "(" <scope> ")" "!"? ":" <whitespace>* <text>
+               |  <type> "!"? ":" <whitespace>* <text>
+<type>         ::= <any UTF8-octets except newline or parens or ":" or "!:" or whitespace>+
+<scope>        ::= <any UTF8-octets except newline or parens>+
+<text>         ::= <any UTF8-octets except newline>+
 
-<body-footer>  ::= 1*<footer>
-               ::= <body> <newline> 1*<body-footer>
-               ::= <body>
+/* Note: if the first <body> node starts with "BREAKING CHANGE:" this should
+ * be treated by parsers as a breaking change marker upstream:
+ */
+<body-footer>  ::= <footer>+
+               | <body> <newline> <body-footer>*
+               | <body>
+<body>         ::= <text>?
 
-<footer>       ::= <token> <separator> *<whitespace> <value> <newline>?
+<footer>       ::= <token> <separator> <whitespace>* <value> <newline>?
 <token>        ::= "BREAKING CHANGE"
-                |  <type> "(" <scope> ")"
-                |  <type>
-<separator>    ::= <summary-sep> | ' #'
-<value>        ::= <text> 1*<continuation>
-                |  <text>
+               |  <type> "(" <scope> ")" "!"?
+               |  <type> "!"?
+<separator>    ::= ":" | " #"
+<value>        ::= <text> <continuation>+
+               | <text>
 <continuation> ::= <newline> <whitespace> <text>
-
-<body>         ::= <text>? <newline>
 ```

--- a/README.md
+++ b/README.md
@@ -20,46 +20,47 @@ to keep this in sync with the written specification on conventionalcommits.org.
 ```ebnf
 /* See: https://tools.ietf.org/html/rfc3629#section-4 */
 <UTF8-char>     ::= "Placeholder for UTF-8 grammar"
-<UTF8-octets>   ::= <UTF8-char>+
+<UTF8-octets>   ::= <UTF8char>+
 
-<CR>           ::= "0x000D"
-<LF>           ::= "0x000A"
-<newline>      ::= <CR>? <LF>
-<parens>       ::= "(" | ")"
-<ZWNBSP>       ::= "U+FEFF"
-<TAB>          ::= "U+0009"
-<VT>           ::= "U+000B"
-<FF>           ::= "U+000C"
-<SP>           ::= "U+0020"
-<NBSP>         ::= "U+00A0"
+<CR>            ::= "0x000D"
+<LF>            ::= "0x000A"
+<newline>       ::= [<CR>], <LF>
+<parens>        ::= "(" | ")"
+<ZWNBSP>        ::= "U+FEFF"
+<TAB>           ::= "U+0009"
+<VT>            ::= "U+000B"
+<FF>            ::= "U+000C"
+<SP>            ::= "U+0020"
+<NBSP>          ::= "U+00A0"
 /* See: https://www.ecma-international.org/ecma-262/11.0/index.html#sec-white-space */
-<USP>          ::= "Any other Unicode 'Space_Separator' code point"
+<USP>           ::= "Any other Unicode 'Space_Separator' code point"
 /* Any non-newline whitespace: */
-<whitespace>   ::= <ZWNBSP> | <TAB> | <VT> | <FF> | <SP> | <NBSP> | <USP>
+<whitespace>    ::= <ZWNBSP> | <TAB> | <VT> | <FF> | <SP> | <NBSP> | <USP>
 
-<message>      ::= <summary> <newline> <body-footer>
-               |  <summary>
+<message>       ::= <summary>, <newline>, <bodyfooter>
+                 |  <summary>
 
-<summary>      ::= <type> "(" <scope> ")" "!"? ":" <whitespace>* <text>
-               |  <type> "!"? ":" <whitespace>* <text>
-<type>         ::= <any UTF8-octets except newline or parens or ":" or "!:" or whitespace>+
-<scope>        ::= <any UTF8-octets except newline or parens>+
-<text>         ::= <any UTF8-octets except newline>+
+<summary>       ::= <type>, "(", <scope>, ")", ["!"], ":", <whitespace>*, <text>
+                 |  <type>, ["!"], ":", <whitespace>*, <text>
+<type>          ::= <any UTF8-octets except newline or parens or ":" or "!:" or whitespace>+
+<scope>         ::= <any UTF8-octets except newline or parens>+
+<text>          ::= <any UTF8-octets except newline>+
 
-/* Note: if the first <body> node starts with "BREAKING CHANGE:" this should
+/*
+ * Note: if the first <body> node starts with "BREAKING CHANGE:" this should
  * be treated by parsers as a breaking change marker upstream:
  */
-<body-footer>  ::= <footer>+
-               | <body> <newline> <body-footer>*
-               | <body>
-<body>         ::= <text>?
+<body-footer>   ::= <footer>+
+                 | <body>, <newline>, <body-footer>*
+                 | <body>
+<body>          ::= [<text>]
 
-<footer>       ::= <token> <separator> <whitespace>* <value> <newline>?
-<token>        ::= "BREAKING CHANGE"
-               |  <type> "(" <scope> ")" "!"?
-               |  <type> "!"?
-<separator>    ::= ":" | " #"
-<value>        ::= <text> <continuation>+
-               | <text>
-<continuation> ::= <newline> <whitespace> <text>
+<footer>        ::= <token>, <separator>, <whitespace>*, <value>, [<newline>]
+<token>         ::= "BREAKING CHANGE"
+                 |  <type>, "(" <scope> ")", ["!"]
+                 |  <type>, ["!"]
+<separator>     ::= ":" | " #"
+<value>         ::= <text>, <continuation>+
+                 | <text>
+<continuation> ::= <newline>, <whitespace>, <text>
 ```


### PR DESCRIPTION
Did a bit more reading about EBNF syntax. This should be closer to what's expected by GitHub's syntax highlighting.