### PR TITLE
chore: add inspect command to debug trees

### DIFF
--- a/inspect.js
+++ b/inspect.js
@@ -1,0 +1,16 @@
+const parse = require('.')
+const inspect = require('unist-util-inspect')
+const { hideBin } = require('yargs/helpers')
+const yargs = require('yargs/yargs')(hideBin(process.argv))
+
+const argv = yargs
+  .command('$0', 'Output the parsed syntax tree\n\nUsage: npm run inspect <message>')
+  .argv
+
+const message = argv._[0]
+
+if (message) {
+  console.log(inspect(parse(message)))
+} else {
+  yargs.showHelp()
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "c8 mocha test.js",
     "test:snap": "CHAI_JEST_SNAPSHOT_UPDATE_ALL=true npm test",
     "posttest": "standard",
-    "fix": "standard --fix"
+    "fix": "standard --fix",
+    "inspect": "node inspect.js"
   },
   "repository": {
     "type": "git",
@@ -29,6 +30,8 @@
     "chai": "^4.2.0",
     "chai-jest-snapshot": "^2.0.0",
     "mocha": "^8.2.1",
-    "standard": "^16.0.3"
+    "standard": "^16.0.3",
+    "unist-util-inspect": "^6.0.1",
+    "yargs": "^16.2.0"
   }
 }


### PR DESCRIPTION
This adds the `npm run inspect <message>` command. It's helpful to validate if changes made to e.g. positioning are sensible.

help | example
--- | ---
![help](https://user-images.githubusercontent.com/1203991/102725427-fe511400-4316-11eb-92e7-14f33e422fd6.png) | ![example](https://user-images.githubusercontent.com/1203991/102725429-ff824100-4316-11eb-87bf-ab41878aa493.png)
