### PR TITLE
refactor: split summary-sep to breaking change and separator

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function message (commitText) {
   if (isNewline(scanner.peek())) {
     scanner.next()
   } else {
-    return invalidToken(scanner, ['none'])
+    throw invalidToken(scanner, ['none'])
   }
   node.children.push(bodyFooter(scanner))
   node.position = { start, end: scanner.position() }

--- a/index.js
+++ b/index.js
@@ -281,12 +281,9 @@ function breakingChange (scanner) {
     value: ''
   }
   if (scanner.peek() === '!') {
-    scanner.next()
-    node.value = '!'
-  }
-  if (scanner.peekLiteral('BREAKING CHANGE')) {
-    const literal = scanner.next('BREAKING CHANGE'.length)
-    node.value = literal
+    node.value = scanner.next()
+  } else if (scanner.peekLiteral('BREAKING CHANGE')) {
+    node.value = scanner.next('BREAKING CHANGE'.length)
   }
   if (node.value === '') {
     return invalidToken(scanner, ['BREAKING CHANGE'])

--- a/index.js
+++ b/index.js
@@ -137,6 +137,7 @@ function summarySep (scanner) {
     children: []
   }
   if (isSummarySep(scanner.peek())) {
+    // todo: position needs to be broken up for the `!:` token
     scanner.next()
     // manually offset the end with half the "!:" size
     const breakingEnd = scanner.position()
@@ -157,6 +158,7 @@ function summarySep (scanner) {
       position: { start: separatorStart, end: scanner.position() }
     })
   } else if (scanner.peek() === ':') {
+    const start = scanner.position()
     scanner.next()
     node.children.push({
       type: 'separator',

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const Scanner = require('./lib/scanner')
-const { isWhitespace, isNewline, isParens, isSummarySep } = require('./lib/type-checks')
+const { isWhitespace, isNewline, isParens } = require('./lib/type-checks')
 
 /*
  * <message>      ::= <summary> <newline> <body-footer>
@@ -28,7 +28,7 @@ function message (commitText) {
   if (isNewline(scanner.peek())) {
     scanner.next()
   } else {
-    invalidToken(scanner, ['none'])
+    return invalidToken(scanner, ['none'])
   }
   node.children.push(bodyFooter(scanner))
   node.position = { start, end: scanner.position() }
@@ -36,8 +36,8 @@ function message (commitText) {
 }
 
 /*
- * <summary>      ::= <type> "(" <scope> ")" <summary-sep> <text>
- *                 |  <type> <summary-sep> <text>
+ * <summary>      ::= <type> "(" <scope> ")" ["!"] ": " <text>
+ *                 |  <type> ["!"] ": " <text>
  *
  */
 function summary (scanner) {
@@ -54,12 +54,8 @@ function summary (scanner) {
     node.children.push(t)
   }
 
-  if (scanner.peek() === ':' || isSummarySep(scanner.peek())) {
-    // <type> <summary-sep> <text>
-    node.children.push(summarySep(scanner))
-    node.children.push(text(scanner))
-  } else if (scanner.peek() === '(') {
-    // <type> "(" <scope> ")" <summary-sep> <text>
+  if (scanner.peek() === '(') {
+    // <type> "(" <scope> ")" ...
     scanner.next()
     const s = scope(scanner)
     if (s instanceof Error) {
@@ -67,18 +63,27 @@ function summary (scanner) {
     } else {
       node.children.push(s)
     }
-    if (scanner.peek() !== ')') return invalidToken(scanner, [')'])
-    scanner.next()
-    const sep = summarySep(scanner)
-    if (sep instanceof Error) {
-      return sep
-    } else {
-      node.children.push(sep)
+    if (scanner.peek() !== ')') {
+      return invalidToken(scanner, [')'])
     }
-    node.children.push(text(scanner))
-  } else {
-    return invalidToken(scanner, [':', '('])
+    scanner.next()
   }
+
+  // ... ["!"] ...
+  const b = breakingChange(scanner)
+  if (!(b instanceof Error)) {
+    node.children.push(b)
+  }
+
+  // ... ": " <text>
+  const sep = separator(scanner)
+  if (sep instanceof Error) {
+    return invalidToken(scanner, [':', '(', '!'])
+  } else {
+    node.children.push(sep)
+  }
+
+  node.children.push(text(scanner))
   node.position = { start, end: scanner.position() }
   return node
 }
@@ -94,7 +99,7 @@ function type (scanner) {
   }
   while (!scanner.eof()) {
     const token = scanner.peek()
-    if (isParens(token) || isWhitespace(token) || isNewline(token) || isSummarySep(token) || token === ':') {
+    if (isParens(token) || isWhitespace(token) || isNewline(token) || token === '!' || token === ':') {
       break
     }
     node.value += scanner.next()
@@ -124,49 +129,6 @@ function text (scanner) {
     node.value += scanner.next()
   }
   node.position = { start, end: scanner.position() }
-  return node
-}
-
-/*
- * <summary-sep>  ::= "!"? ":" *<whitespace>
- */
-function summarySep (scanner) {
-  const start = scanner.position()
-  const node = {
-    type: 'summary-sep',
-    children: []
-  }
-  if (isSummarySep(scanner.peek())) {
-    scanner.next()
-    // manually offset the end with half the "!:" size
-    const breakingEnd = scanner.position()
-    breakingEnd.offset--
-    breakingEnd.column--
-    node.children.push({
-      type: 'breaking-change',
-      value: '!',
-      position: { start, end: breakingEnd }
-    })
-    // manually offset the start with half the "!:" size
-    const separatorStart = scanner.position()
-    separatorStart.offset--
-    separatorStart.column--
-    node.children.push({
-      type: 'separator',
-      value: ':',
-      position: { start: separatorStart, end: scanner.position() }
-    })
-  } else if (scanner.peek() === ':') {
-    scanner.next()
-    node.children.push({
-      type: 'separator',
-      value: ':',
-      position: { start, end: scanner.position() }
-    })
-  } else {
-    return invalidToken(scanner, [':'])
-  }
-  scanner.consumeWhitespace()
   return node
 }
 
@@ -274,7 +236,7 @@ function token (scanner) {
 
   // "BREAKING CHANGE"
   const start = scanner.position()
-  const b = breakingChangeLiteral(scanner)
+  const b = breakingChange(scanner)
   if (b instanceof Error) {
     scanner.rewind(start)
   } else {
@@ -309,11 +271,15 @@ function token (scanner) {
 /*
  * "BREAKING CHANGE"
  */
-function breakingChangeLiteral (scanner) {
+function breakingChange (scanner) {
   const start = scanner.position()
   const node = {
     type: 'breaking-change',
     value: ''
+  }
+  if (scanner.peek() === '!') {
+    scanner.next()
+    node.value = '!'
   }
   if (scanner.peekLiteral('BREAKING CHANGE')) {
     const literal = scanner.next('BREAKING CHANGE'.length)
@@ -373,20 +339,26 @@ function continuation (scanner) {
 }
 
 /*
- * <separator>    ::= <summary-sep> | ' #'
+ * <separator>    ::= ": " | " #"
  */
 function separator (scanner) {
+  const start = scanner.position()
   const node = {
     type: 'separator',
     value: ''
   }
-  // <summary-sep>
-  const start = scanner.position()
-  const sum = summarySep(scanner)
-  if (sum instanceof Error) {
-    scanner.rewind(start)
-  } else {
-    return sum
+
+  // ': '
+  if (scanner.peek() === ':') {
+    scanner.next()
+    if (scanner.peek() === ' ') {
+      node.value = ': '
+      scanner.next()
+      node.position = { start, end: scanner.position() }
+      return node
+    } else {
+      return invalidToken(scanner, ['separator'])
+    }
   }
 
   // ' #'
@@ -395,13 +367,14 @@ function separator (scanner) {
     if (scanner.peek() === '#') {
       scanner.next()
       node.value = ' #'
+      node.position = { start, end: scanner.position() }
     } else {
+      scanner.rewind(start)
       return invalidToken(scanner, ['separator'])
     }
   } else {
     return invalidToken(scanner, ['separator'])
   }
-  node.position = { start, end: scanner.position() }
   return node
 }
 

--- a/index.js
+++ b/index.js
@@ -71,15 +71,17 @@ function summary (scanner) {
   }
 
   // ... ["!"] ...
-  const b = breakingChange(scanner)
-  if (!(b instanceof Error)) {
+  let b = breakingChange(scanner)
+  if (b instanceof Error) {
+    b = null
+  } else {
     node.children.push(b)
   }
 
   // ... ": " <text>
   const sep = separator(scanner)
   if (sep instanceof Error) {
-    return invalidToken(scanner, [':', '!', !s && '('])
+    return invalidToken(scanner, [!s && '(', !b && '!', ':'])
   } else {
     node.children.push(sep)
   }

--- a/index.js
+++ b/index.js
@@ -137,7 +137,6 @@ function summarySep (scanner) {
     children: []
   }
   if (isSummarySep(scanner.peek())) {
-    // todo: position needs to be broken up for the `!:` token
     scanner.next()
     // manually offset the end with half the "!:" size
     const breakingEnd = scanner.position()
@@ -158,7 +157,6 @@ function summarySep (scanner) {
       position: { start: separatorStart, end: scanner.position() }
     })
   } else if (scanner.peek() === ':') {
-    const start = scanner.position()
     scanner.next()
     node.children.push({
       type: 'separator',

--- a/index.js
+++ b/index.js
@@ -140,8 +140,8 @@ function summarySep (scanner) {
     scanner.next()
     // manually offset the end with half the "!:" size
     const breakingEnd = scanner.position()
-    breakingEnd.offset--
-    breakingEnd.column--
+    breakingEnd.offset--;
+    breakingEnd.column--;
     node.children.push({
       type: 'breaking-change',
       value: '!',
@@ -149,8 +149,8 @@ function summarySep (scanner) {
     })
     // manually offset the start with half the "!:" size
     const separatorStart = scanner.position()
-    separatorStart.offset--
-    separatorStart.column--
+    separatorStart.offset--;
+    separatorStart.column--;
     node.children.push({
       type: 'separator',
       value: ':',

--- a/index.js
+++ b/index.js
@@ -54,10 +54,11 @@ function summary (scanner) {
     node.children.push(t)
   }
 
+  let s
   if (scanner.peek() === '(') {
     // <type> "(" <scope> ")" ...
     scanner.next()
-    const s = scope(scanner)
+    s = scope(scanner)
     if (s instanceof Error) {
       return s
     } else {
@@ -78,7 +79,7 @@ function summary (scanner) {
   // ... ": " <text>
   const sep = separator(scanner)
   if (sep instanceof Error) {
-    return invalidToken(scanner, [':', '(', '!'])
+    return invalidToken(scanner, [':', '!', !s && '('])
   } else {
     node.children.push(sep)
   }
@@ -379,11 +380,12 @@ function separator (scanner) {
 }
 
 function invalidToken (scanner, expected) {
+  const validTokens = expected.filter(Boolean).join(', ')
   if (scanner.eof()) {
-    return Error(`unexpected token EOF valid tokens [${expected.join(', ')}]`)
+    return Error(`unexpected token EOF valid tokens [${validTokens}]`)
   } else {
     const pos = scanner.position()
-    return Error(`unexpected token '${scanner.peek()}' at position ${pos.line}:${pos.column} valid tokens [${expected.join(', ')}]`)
+    return Error(`unexpected token '${scanner.peek()}' at position ${pos.line}:${pos.column} valid tokens [${validTokens}]`)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -140,8 +140,8 @@ function summarySep (scanner) {
     scanner.next()
     // manually offset the end with half the "!:" size
     const breakingEnd = scanner.position()
-    breakingEnd.offset--;
-    breakingEnd.column--;
+    breakingEnd.offset--
+    breakingEnd.column--
     node.children.push({
       type: 'breaking-change',
       value: '!',
@@ -149,8 +149,8 @@ function summarySep (scanner) {
     })
     // manually offset the start with half the "!:" size
     const separatorStart = scanner.position()
-    separatorStart.offset--;
-    separatorStart.column--;
+    separatorStart.offset--
+    separatorStart.column--
     node.children.push({
       type: 'separator',
       value: ':',

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ function summary (scanner) {
 }
 
 /*
- * <type>         ::= 1*<any UTF8-octets except newline or parens or ":" or "!:" or whitespace>
+ * <type>         ::= 1*<any UTF8-octets except newline or parens or ["!"] ":" or whitespace>
  */
 function type (scanner) {
   const start = scanner.position()
@@ -227,7 +227,7 @@ function footer (scanner) {
 }
 
 /*
- * <token>        ::= "BREAKING CHANGE"
+ * <token>        ::= <breaking-change>
  *                 |  <type> "(" <scope> ")"
  *                 |  <type>
  */
@@ -272,7 +272,7 @@ function token (scanner) {
 }
 
 /*
- * "BREAKING CHANGE"
+ * <breaking-change> ::= "!" | "BREAKING CHANGE"
  */
 function breakingChange (scanner) {
   const start = scanner.position()

--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -44,9 +44,6 @@ class Scanner {
     // Consume <CR>? <LF>
     if (token === CR && this.text.charAt(this.pos.offset + 1) === LF) {
       token += LF
-    // Consume ?: separator
-    } else if (token === '!' && this.text.charAt(this.pos.offset + 1) === ':') {
-      token += ':'
     }
     return token
   }

--- a/lib/type-checks.js
+++ b/lib/type-checks.js
@@ -21,12 +21,5 @@ module.exports = {
   */
   isParens (token) {
     return token === '(' || token === ')'
-  },
-
-  /*
-   * <summary-sep>  ::= "!"? ":" *<whitespace>
-   */
-  isSummarySep (token) {
-    return token === '!:'
   }
 }

--- a/test.js
+++ b/test.js
@@ -29,10 +29,13 @@ describe('<message>', () => {
     it('throws error when ":" token is missing', () => {
       expect(() => {
         parser('feat add support for scopes')
-      }).to.throw("unexpected token ' ' at position 1:5 valid tokens [:, (]")
+      }).to.throw("unexpected token ' ' at position 1:5 valid tokens [(, !, :]")
       expect(() => {
         parser('feat( foo ) add support for scopes')
-      }).to.throw("unexpected token ' ' at position 1:12 valid tokens [:]")
+      }).to.throw("unexpected token ' ' at position 1:12 valid tokens [!, :]")
+      expect(() => {
+        parser('feat(bar)! add support for breaking change')
+      }).to.throw("unexpected token ' ' at position 1:11 valid tokens [:]")
     })
     it('throws error when closing ")" token is missing', () => {
       expect(() => {

--- a/test.js.snap
+++ b/test.js.snap
@@ -22,25 +22,20 @@ Object {
           "value": "fix",
         },
         Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 5,
-                  "line": 1,
-                  "offset": 4,
-                },
-                "start": Object {
-                  "column": 4,
-                  "line": 1,
-                  "offset": 3,
-                },
-              },
-              "type": "separator",
-              "value": ":",
+          "position": Object {
+            "end": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
             },
-          ],
-          "type": "summary-sep",
+            "start": Object {
+              "column": 4,
+              "line": 1,
+              "offset": 3,
+            },
+          },
+          "type": "separator",
+          "value": ": ",
         },
         Object {
           "position": Object {
@@ -111,25 +106,20 @@ Object {
               "type": "token",
             },
             Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "end": Object {
-                      "column": 17,
-                      "line": 2,
-                      "offset": 39,
-                    },
-                    "start": Object {
-                      "column": 16,
-                      "line": 2,
-                      "offset": 38,
-                    },
-                  },
-                  "type": "separator",
-                  "value": ":",
+              "position": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 2,
+                  "offset": 40,
                 },
-              ],
-              "type": "summary-sep",
+                "start": Object {
+                  "column": 16,
+                  "line": 2,
+                  "offset": 38,
+                },
+              },
+              "type": "separator",
+              "value": ": ",
             },
             Object {
               "children": Array [
@@ -233,25 +223,20 @@ Object {
           "value": "chore",
         },
         Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 7,
-                  "line": 1,
-                  "offset": 6,
-                },
-                "start": Object {
-                  "column": 6,
-                  "line": 1,
-                  "offset": 5,
-                },
-              },
-              "type": "separator",
-              "value": ":",
+          "position": Object {
+            "end": Object {
+              "column": 8,
+              "line": 1,
+              "offset": 7,
             },
-          ],
-          "type": "summary-sep",
+            "start": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+          },
+          "type": "separator",
+          "value": ": ",
         },
         Object {
           "position": Object {
@@ -338,25 +323,20 @@ Object {
               "type": "token",
             },
             Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "end": Object {
-                      "column": 13,
-                      "line": 2,
-                      "offset": 45,
-                    },
-                    "start": Object {
-                      "column": 12,
-                      "line": 2,
-                      "offset": 44,
-                    },
-                  },
-                  "type": "separator",
-                  "value": ":",
+              "position": Object {
+                "end": Object {
+                  "column": 14,
+                  "line": 2,
+                  "offset": 46,
                 },
-              ],
-              "type": "summary-sep",
+                "start": Object {
+                  "column": 12,
+                  "line": 2,
+                  "offset": 44,
+                },
+              },
+              "type": "separator",
+              "value": ": ",
             },
             Object {
               "children": Array [
@@ -460,25 +440,20 @@ Object {
           "value": "fix",
         },
         Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 5,
-                  "line": 1,
-                  "offset": 4,
-                },
-                "start": Object {
-                  "column": 4,
-                  "line": 1,
-                  "offset": 3,
-                },
-              },
-              "type": "separator",
-              "value": ":",
+          "position": Object {
+            "end": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
             },
-          ],
-          "type": "summary-sep",
+            "start": Object {
+              "column": 4,
+              "line": 1,
+              "offset": 3,
+            },
+          },
+          "type": "separator",
+          "value": ": ",
         },
         Object {
           "position": Object {
@@ -549,25 +524,20 @@ Object {
               "type": "token",
             },
             Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "end": Object {
-                      "column": 8,
-                      "line": 2,
-                      "offset": 30,
-                    },
-                    "start": Object {
-                      "column": 7,
-                      "line": 2,
-                      "offset": 29,
-                    },
-                  },
-                  "type": "separator",
-                  "value": ":",
+              "position": Object {
+                "end": Object {
+                  "column": 9,
+                  "line": 2,
+                  "offset": 31,
                 },
-              ],
-              "type": "summary-sep",
+                "start": Object {
+                  "column": 7,
+                  "line": 2,
+                  "offset": 29,
+                },
+              },
+              "type": "separator",
+              "value": ": ",
             },
             Object {
               "children": Array [
@@ -671,25 +641,20 @@ Object {
           "value": "fix",
         },
         Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 5,
-                  "line": 1,
-                  "offset": 4,
-                },
-                "start": Object {
-                  "column": 4,
-                  "line": 1,
-                  "offset": 3,
-                },
-              },
-              "type": "separator",
-              "value": ":",
+          "position": Object {
+            "end": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
             },
-          ],
-          "type": "summary-sep",
+            "start": Object {
+              "column": 4,
+              "line": 1,
+              "offset": 3,
+            },
+          },
+          "type": "separator",
+          "value": ": ",
         },
         Object {
           "position": Object {
@@ -760,25 +725,20 @@ Object {
               "type": "token",
             },
             Object {
-              "children": Array [
-                Object {
-                  "position": Object {
-                    "end": Object {
-                      "column": 17,
-                      "line": 2,
-                      "offset": 39,
-                    },
-                    "start": Object {
-                      "column": 16,
-                      "line": 2,
-                      "offset": 38,
-                    },
-                  },
-                  "type": "separator",
-                  "value": ":",
+              "position": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 2,
+                  "offset": 40,
                 },
-              ],
-              "type": "summary-sep",
+                "start": Object {
+                  "column": 16,
+                  "line": 2,
+                  "offset": 38,
+                },
+              },
+              "type": "separator",
+              "value": ": ",
             },
             Object {
               "children": Array [
@@ -948,41 +908,36 @@ Object {
           "value": "feat",
         },
         Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 6,
-                  "line": 1,
-                  "offset": 5,
-                },
-                "start": Object {
-                  "column": 5,
-                  "line": 1,
-                  "offset": 4,
-                },
-              },
-              "type": "breaking-change",
-              "value": "!",
+          "position": Object {
+            "end": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
             },
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 7,
-                  "line": 1,
-                  "offset": 6,
-                },
-                "start": Object {
-                  "column": 6,
-                  "line": 1,
-                  "offset": 5,
-                },
-              },
-              "type": "separator",
-              "value": ":",
+            "start": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
             },
-          ],
-          "type": "summary-sep",
+          },
+          "type": "breaking-change",
+          "value": "!",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 8,
+              "line": 1,
+              "offset": 7,
+            },
+            "start": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+          },
+          "type": "separator",
+          "value": ": ",
         },
         Object {
           "position": Object {
@@ -1070,41 +1025,36 @@ Object {
           "value": "http parser",
         },
         Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 19,
-                  "line": 1,
-                  "offset": 18,
-                },
-                "start": Object {
-                  "column": 18,
-                  "line": 1,
-                  "offset": 17,
-                },
-              },
-              "type": "breaking-change",
-              "value": "!",
+          "position": Object {
+            "end": Object {
+              "column": 19,
+              "line": 1,
+              "offset": 18,
             },
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 20,
-                  "line": 1,
-                  "offset": 19,
-                },
-                "start": Object {
-                  "column": 19,
-                  "line": 1,
-                  "offset": 18,
-                },
-              },
-              "type": "separator",
-              "value": ":",
+            "start": Object {
+              "column": 18,
+              "line": 1,
+              "offset": 17,
             },
-          ],
-          "type": "summary-sep",
+          },
+          "type": "breaking-change",
+          "value": "!",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 21,
+              "line": 1,
+              "offset": 20,
+            },
+            "start": Object {
+              "column": 19,
+              "line": 1,
+              "offset": 18,
+            },
+          },
+          "type": "separator",
+          "value": ": ",
         },
         Object {
           "position": Object {
@@ -1176,25 +1126,20 @@ Object {
           "value": "fix",
         },
         Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 5,
-                  "line": 1,
-                  "offset": 4,
-                },
-                "start": Object {
-                  "column": 4,
-                  "line": 1,
-                  "offset": 3,
-                },
-              },
-              "type": "separator",
-              "value": ":",
+          "position": Object {
+            "end": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
             },
-          ],
-          "type": "summary-sep",
+            "start": Object {
+              "column": 4,
+              "line": 1,
+              "offset": 3,
+            },
+          },
+          "type": "separator",
+          "value": ": ",
         },
         Object {
           "position": Object {
@@ -1282,25 +1227,20 @@ Object {
           "value": "parser",
         },
         Object {
-          "children": Array [
-            Object {
-              "position": Object {
-                "end": Object {
-                  "column": 14,
-                  "line": 1,
-                  "offset": 13,
-                },
-                "start": Object {
-                  "column": 13,
-                  "line": 1,
-                  "offset": 12,
-                },
-              },
-              "type": "separator",
-              "value": ":",
+          "position": Object {
+            "end": Object {
+              "column": 15,
+              "line": 1,
+              "offset": 14,
             },
-          ],
-          "type": "summary-sep",
+            "start": Object {
+              "column": 13,
+              "line": 1,
+              "offset": 12,
+            },
+          },
+          "type": "separator",
+          "value": ": ",
         },
         Object {
           "position": Object {


### PR DESCRIPTION
This removes the `summary-sep` and splits it up into `separator` and `breaking-change`.  With these changes, we:

<details>
<summary>1. flatten the <code>message.summary</code> to this</summary>
<img width="516" alt="Screenshot 2020-12-22 at 02 10 58" src="https://user-images.githubusercontent.com/1203991/102836924-efdc2880-43fa-11eb-9d0f-493734b3d30b.png">
</details>

<details>
<summary>2. flatten the <code>body-footer</code> structure</summary>
<img width="651" alt="Screenshot 2020-12-22 at 02 11 33" src="https://user-images.githubusercontent.com/1203991/102836954-04b8bc00-43fb-11eb-8c92-4dd6a8c56dc1.png">
</details>

<details>
<summary>3. while maintaining only a single <code>breaking-change</code> node type</summary>
<img width="942" alt="Screenshot 2020-12-22 at 02 15 01" src="https://user-images.githubusercontent.com/1203991/102837137-80b30400-43fb-11eb-8795-8b016920c271.png">
</details>

If we want to make this a CST, we should be able to convert the tree back to string without any change. That's why I added the `: ` (space) to the `separator` node type. But, we can also add a `whitespace` node type, or decide to just skip that for now and focus on an AST.

> This PR is stacked on #5, I think that PR is ready with the exception of the node builder. But I'd like to do that in a different PR.