### PR TITLE
chore: limit files included in npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "description": "reference implementation of conventionalcommits.org spec",
   "main": "index.js",
+  "files": [
+    "lib",
+    "index.js"
+  ],
   "scripts": {
     "test": "c8 mocha test.js",
     "test:snap": "CHAI_JEST_SNAPSHOT_UPDATE_ALL=true npm test",


### PR DESCRIPTION
We don't need to ship testing or script files when publishing the package on NPM. Let's limit that 😄 