### PR TITLE
refactor: contain scope parsing in scope method only

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -40,6 +40,7 @@ function message (commitText) {
 function summary (scanner) {
   const node = scanner.enter('summary', [])
 
+  // <type> ...
   const t = type(scanner)
   if (t instanceof Error) {
     return t
@@ -47,20 +48,12 @@ function summary (scanner) {
     node.children.push(t)
   }
 
-  let s
-  if (scanner.peek() === '(') {
-    // <type> "(" <scope> ")" ...
-    scanner.next()
-    s = scope(scanner)
-    if (s instanceof Error) {
-      return s
-    } else {
-      node.children.push(s)
-    }
-    if (scanner.peek() !== ')') {
-      return scanner.abort(node, [')'])
-    }
-    scanner.next()
+  // ... "(" <scope> ")" ...
+  let s = scope(scanner)
+  if (s instanceof Error) {
+    s = null
+  } else {
+    node.children.push(s)
   }
 
   // ... ["!"] ...
@@ -118,10 +111,17 @@ function text (scanner) {
 }
 
 /*
- * <scope>        ::= 1*<any UTF8-octets except newline or parens>
+ * "(" <scope> ")"        ::= 1*<any UTF8-octets except newline or parens>
  */
 function scope (scanner) {
+  if (scanner.peek() !== '(') {
+    return scanner.abort(scanner.enter('scope', ''))
+  } else {
+    scanner.next()
+  }
+
   const node = scanner.enter('scope', '')
+
   while (!scanner.eof()) {
     const token = scanner.peek()
     if (isParens(token) || isNewline(token)) {
@@ -130,10 +130,17 @@ function scope (scanner) {
     node.value += scanner.next()
   }
 
+  if (scanner.peek() !== ')') {
+    throw scanner.abort(node, [')'])
+  } else {
+    scanner.exit(node)
+    scanner.next()
+  }
+
   if (node.value === '') {
     return scanner.abort(node)
   } else {
-    return scanner.exit(node)
+    return node
   }
 }
 
@@ -229,19 +236,10 @@ function token (scanner) {
     return t
   } else {
     node.children.push(t)
-    // <type> "(" <scope> ")"
-    if (scanner.peek() === '(') {
-      scanner.next()
-      const s = scope(scanner)
-      if (s instanceof Error) {
-        return s
-      } else {
-        node.children.push(s)
-      }
-      if (scanner.peek() !== ')') {
-        return scanner.abort(node, [')'])
-      }
-      scanner.next()
+    // "(" <scope> ")"
+    const s = scope(scanner)
+    if (!(s instanceof Error)) {
+      node.children.push(s)
     }
     // ["!"]
     const b = breakingChange(scanner)


### PR DESCRIPTION
Note, this is just a try-out. Feel free to close this if it's too much.

One thing I'm not a fan of is having certain tokens spread out to parse a node. The `scope` is the biggest one that's currently a bit spread. E.g. 
- in the summary we [check for opening and closing parenthesis](https://github.com/conventional-commits/parser/blob/main/lib/parser.js#L51-L64)
- but we do this [also in the `token` parsing](https://github.com/conventional-commits/parser/blob/main/lib/parser.js#L233-L245)

Having it contained within the parsing method might help cleaning this up.

