### PR TITLE
fix: use new parser export name in inspect script

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,4 @@
 const visit = require('unist-util-visit')
-const parser = require('./parser')
 
 // Converts conventional commit AST into conventional-changelog's
 // output format, see: https://www.npmjs.com/package/conventional-commits-parser
@@ -78,9 +77,6 @@ function toConventionalChangelogFormat (ast) {
 
   return cc
 }
-
-const ast = parser('feat(hello world)!: this is an awesome feature\n\nthis is the body text\n\nsecond line of body\nmoar body')
-toConventionalChangelogFormat(ast)
 
 module.exports = {
   toConventionalChangelogFormat

--- a/scripts/inspect.js
+++ b/scripts/inspect.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
-const parse = require('..')
+const { parser } = require('..')
 const inspect = require('unist-util-inspect')
 const { hideBin } = require('yargs/helpers')
 const yargs = require('yargs/yargs')(hideBin(process.argv))
 
 yargs
   .command('$0 <message>', 'Output the parsed syntax tree', () => {}, (argv) => {
-    console.log(inspect(parse(argv.message)))
+    console.log(inspect(parser(argv.message)))
   })
   .parse()


### PR DESCRIPTION
Sorry I missed this in your PR @bcoe. Found it when testing #22.  