### PR TITLE
feat: add greedy whitespace tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,5 +84,5 @@ in sync with the written specification on conventionalcommits.org.
 <separator>     ::= ":" | " #"
 <value>         ::= <text>, <continuation>+
                  | <text>
-<continuation> ::= <newline>, <whitespace>, <text>
+<continuation> ::= <newline>, <whitespace>+, <text>
 ```

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -33,8 +33,8 @@ function message (commitText) {
 }
 
 /*
- * <summary>      ::= <type> "(" <scope> ")" ["!"] ": " <text>
- *                 |  <type> ["!"] ": " <text>
+ * <summary>      ::= <type> "(" <scope> ")" ["!"] ":" <whitespace>* <text>
+ *                 |  <type> ["!"] ":" <whitespace>* <text>
  *
  */
 function summary (scanner) {
@@ -71,7 +71,7 @@ function summary (scanner) {
     node.children.push(b)
   }
 
-  // ... ": " <text>
+  // ... ":" ...
   const sep = separator(scanner)
   if (sep instanceof Error) {
     return scanner.abort(node, [!s && '(', !b && '!', ':'])
@@ -79,6 +79,13 @@ function summary (scanner) {
     node.children.push(sep)
   }
 
+  // ... <whitespace>* ...
+  const ws = whitespace(scanner)
+  if (!(ws instanceof Error)) {
+    node.children.push(ws)
+  }
+
+  // ... <text>
   node.children.push(text(scanner))
   return scanner.exit(node)
 }
@@ -173,7 +180,7 @@ function body (scanner) {
 }
 
 /*
- * <footer>       ::= <token> <separator> *<whitespace> <value> <newline>?
+ * <footer>       ::= <token> <separator> <whitespace>* <value> <newline>?
 */
 function footer (scanner) {
   const node = scanner.enter('footer', [])
@@ -185,14 +192,19 @@ function footer (scanner) {
     node.children.push(t)
   }
 
-  // <separator> *<whitespace>
+  // <separator>
   const s = separator(scanner)
   if (s instanceof Error) {
     return s
   } else {
     node.children.push(s)
   }
-  scanner.consumeWhitespace()
+
+  // <whitespace>*
+  const ws = whitespace(scanner)
+  if (!(ws instanceof Error)) {
+    node.children.push(ws)
+  }
 
   // <value> <newline>?
   const v = value(scanner)
@@ -270,14 +282,14 @@ function breakingChange (scanner) {
 }
 
 /*
- * <value>        ::= <text> 1*<continuation>
+ * <value>        ::= <text> <continuation>*
  *                 |  <text>
  */
 function value (scanner) {
   const node = scanner.enter('value', [])
   node.children.push(text(scanner))
   let c
-  // 1*<continuation>
+  // <continuation>*
   while (!((c = continuation(scanner)) instanceof Error)) {
     node.children.push(c)
   }
@@ -291,11 +303,12 @@ function continuation (scanner) {
   const node = scanner.enter('continuation', [])
   if (isNewline(scanner.peek())) {
     scanner.next()
-    if (isWhitespace(scanner.peek())) {
-      scanner.next()
-      node.children.push(text(scanner))
+    const ws = whitespace(scanner)
+    if (ws instanceof Error) {
+      return ws
     } else {
-      return scanner.abort(node)
+      node.children.push(ws)
+      node.children.push(text(scanner))
     }
   } else {
     return scanner.abort(node)
@@ -304,20 +317,14 @@ function continuation (scanner) {
 }
 
 /*
- * <separator>    ::= ": " | " #"
+ * <separator>    ::= ":" | " #"
  */
 function separator (scanner) {
   const node = scanner.enter('separator', '')
-  // ': '
+  // ':'
   if (scanner.peek() === ':') {
-    scanner.next()
-    if (scanner.peek() === ' ') {
-      node.value = ': '
-      scanner.next()
-      return scanner.exit(node)
-    } else {
-      return scanner.abort(node)
-    }
+    node.value = scanner.next()
+    return scanner.exit(node)
   }
 
   // ' #'
@@ -333,6 +340,20 @@ function separator (scanner) {
   }
 
   return scanner.abort(node)
+}
+
+/*
+ * <whitespace>+   ::= <ZWNBSP> | <TAB> | <VT> | <FF> | <SP> | <NBSP> | <USP>
+ */
+function whitespace (scanner) {
+  const node = scanner.enter('whitespace', '')
+  while (isWhitespace(scanner.peek())) {
+    node.value += scanner.next()
+  }
+  if (node.value === '') {
+    return scanner.abort(node, [' '])
+  }
+  return scanner.exit(node)
 }
 
 module.exports = message

--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -1,4 +1,4 @@
-const { isWhitespace, isNewline } = require('./type-checks')
+const { isNewline } = require('./type-checks')
 const { CR, LF } = require('./codes')
 
 class Scanner {
@@ -25,12 +25,6 @@ class Scanner {
     }
 
     return token
-  }
-
-  consumeWhitespace () {
-    while (isWhitespace(this.peek())) {
-      this.next()
-    }
   }
 
   peek () {

--- a/test/parser.js
+++ b/test/parser.js
@@ -26,6 +26,14 @@ describe('<message>', () => {
       parsed = parser('feat(http parser)!: add support for scopes')
       parsed.should.matchSnapshot()
     })
+    it('parses summary with multiple spaces after separator', () => {
+      const parsed = parser('feat(tree):    add whitespace node')
+      parsed.should.matchSnapshot()
+    })
+    it('parses summary without spaces after separator', () => {
+      const parsed = parser('feat(tree):no whitespaces here')
+      parsed.should.matchSnapshot()
+    })
     it('throws error when ":" token is missing', () => {
       expect(() => {
         parser('feat add support for scopes')
@@ -62,6 +70,14 @@ describe('<message>', () => {
     })
     it('supports multiline BREAKING CHANGES, via continuation', () => {
       const parsed = parser('fix: address major bug\nBREAKING CHANGE: first line of breaking change\n second line of breaking change\n third line of breaking change')
+      parsed.should.matchSnapshot()
+    })
+    it('parses footer tokens with multiple whitespaces after separator', () => {
+      const parsed = parser('fix: some stuff\n\nExternal-Id:    1337')
+      parsed.should.matchSnapshot()
+    })
+    it('parses footer tokens without whitespaces after separator', () => {
+      const parsed = parser('fix: some stuff\n\nExternal-Id:1337')
       parsed.should.matchSnapshot()
     })
   })

--- a/test/parser.js.snap
+++ b/test/parser.js.snap
@@ -24,9 +24,9 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 6,
+              "column": 5,
               "line": 1,
-              "offset": 5,
+              "offset": 4,
             },
             "start": Object {
               "column": 4,
@@ -35,7 +35,23 @@ Object {
             },
           },
           "type": "separator",
-          "value": ": ",
+          "value": ":",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+            "start": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+          },
+          "type": "whitespace",
+          "value": " ",
         },
         Object {
           "position": Object {
@@ -108,9 +124,9 @@ Object {
             Object {
               "position": Object {
                 "end": Object {
-                  "column": 18,
+                  "column": 17,
                   "line": 2,
-                  "offset": 40,
+                  "offset": 39,
                 },
                 "start": Object {
                   "column": 16,
@@ -119,7 +135,23 @@ Object {
                 },
               },
               "type": "separator",
-              "value": ": ",
+              "value": ":",
+            },
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 2,
+                  "offset": 40,
+                },
+                "start": Object {
+                  "column": 17,
+                  "line": 2,
+                  "offset": 39,
+                },
+              },
+              "type": "whitespace",
+              "value": " ",
             },
             Object {
               "children": Array [
@@ -225,9 +257,9 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 8,
+              "column": 7,
               "line": 1,
-              "offset": 7,
+              "offset": 6,
             },
             "start": Object {
               "column": 6,
@@ -236,7 +268,23 @@ Object {
             },
           },
           "type": "separator",
-          "value": ": ",
+          "value": ":",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 8,
+              "line": 1,
+              "offset": 7,
+            },
+            "start": Object {
+              "column": 7,
+              "line": 1,
+              "offset": 6,
+            },
+          },
+          "type": "whitespace",
+          "value": " ",
         },
         Object {
           "position": Object {
@@ -325,9 +373,9 @@ Object {
             Object {
               "position": Object {
                 "end": Object {
-                  "column": 14,
+                  "column": 13,
                   "line": 2,
-                  "offset": 46,
+                  "offset": 45,
                 },
                 "start": Object {
                   "column": 12,
@@ -336,7 +384,23 @@ Object {
                 },
               },
               "type": "separator",
-              "value": ": ",
+              "value": ":",
+            },
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 14,
+                  "line": 2,
+                  "offset": 46,
+                },
+                "start": Object {
+                  "column": 13,
+                  "line": 2,
+                  "offset": 45,
+                },
+              },
+              "type": "whitespace",
+              "value": " ",
             },
             Object {
               "children": Array [
@@ -442,9 +506,9 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 8,
+              "column": 7,
               "line": 1,
-              "offset": 7,
+              "offset": 6,
             },
             "start": Object {
               "column": 6,
@@ -453,7 +517,23 @@ Object {
             },
           },
           "type": "separator",
-          "value": ": ",
+          "value": ":",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 8,
+              "line": 1,
+              "offset": 7,
+            },
+            "start": Object {
+              "column": 7,
+              "line": 1,
+              "offset": 6,
+            },
+          },
+          "type": "whitespace",
+          "value": " ",
         },
         Object {
           "position": Object {
@@ -558,9 +638,9 @@ Object {
             Object {
               "position": Object {
                 "end": Object {
-                  "column": 16,
+                  "column": 15,
                   "line": 2,
-                  "offset": 48,
+                  "offset": 47,
                 },
                 "start": Object {
                   "column": 14,
@@ -569,7 +649,23 @@ Object {
                 },
               },
               "type": "separator",
-              "value": ": ",
+              "value": ":",
+            },
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 16,
+                  "line": 2,
+                  "offset": 48,
+                },
+                "start": Object {
+                  "column": 15,
+                  "line": 2,
+                  "offset": 47,
+                },
+              },
+              "type": "whitespace",
+              "value": " ",
             },
             Object {
               "children": Array [
@@ -675,9 +771,9 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 6,
+              "column": 5,
               "line": 1,
-              "offset": 5,
+              "offset": 4,
             },
             "start": Object {
               "column": 4,
@@ -686,7 +782,23 @@ Object {
             },
           },
           "type": "separator",
-          "value": ": ",
+          "value": ":",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+            "start": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+          },
+          "type": "whitespace",
+          "value": " ",
         },
         Object {
           "position": Object {
@@ -759,9 +871,9 @@ Object {
             Object {
               "position": Object {
                 "end": Object {
-                  "column": 9,
+                  "column": 8,
                   "line": 2,
-                  "offset": 31,
+                  "offset": 30,
                 },
                 "start": Object {
                   "column": 7,
@@ -770,7 +882,23 @@ Object {
                 },
               },
               "type": "separator",
-              "value": ": ",
+              "value": ":",
+            },
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 9,
+                  "line": 2,
+                  "offset": 31,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 2,
+                  "offset": 30,
+                },
+              },
+              "type": "whitespace",
+              "value": " ",
             },
             Object {
               "children": Array [
@@ -876,9 +1004,9 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 6,
+              "column": 5,
               "line": 1,
-              "offset": 5,
+              "offset": 4,
             },
             "start": Object {
               "column": 4,
@@ -887,7 +1015,23 @@ Object {
             },
           },
           "type": "separator",
-          "value": ": ",
+          "value": ":",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+            "start": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+          },
+          "type": "whitespace",
+          "value": " ",
         },
         Object {
           "position": Object {
@@ -960,9 +1104,9 @@ Object {
             Object {
               "position": Object {
                 "end": Object {
-                  "column": 18,
+                  "column": 17,
                   "line": 2,
-                  "offset": 40,
+                  "offset": 39,
                 },
                 "start": Object {
                   "column": 16,
@@ -971,7 +1115,23 @@ Object {
                 },
               },
               "type": "separator",
-              "value": ": ",
+              "value": ":",
+            },
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 18,
+                  "line": 2,
+                  "offset": 40,
+                },
+                "start": Object {
+                  "column": 17,
+                  "line": 2,
+                  "offset": 39,
+                },
+              },
+              "type": "whitespace",
+              "value": " ",
             },
             Object {
               "children": Array [
@@ -993,6 +1153,22 @@ Object {
                 },
                 Object {
                   "children": Array [
+                    Object {
+                      "position": Object {
+                        "end": Object {
+                          "column": 2,
+                          "line": 3,
+                          "offset": 71,
+                        },
+                        "start": Object {
+                          "column": 1,
+                          "line": 3,
+                          "offset": 70,
+                        },
+                      },
+                      "type": "whitespace",
+                      "value": " ",
+                    },
                     Object {
                       "position": Object {
                         "end": Object {
@@ -1026,6 +1202,22 @@ Object {
                 },
                 Object {
                   "children": Array [
+                    Object {
+                      "position": Object {
+                        "end": Object {
+                          "column": 2,
+                          "line": 4,
+                          "offset": 103,
+                        },
+                        "start": Object {
+                          "column": 1,
+                          "line": 4,
+                          "offset": 102,
+                        },
+                      },
+                      "type": "whitespace",
+                      "value": " ",
+                    },
                     Object {
                       "position": Object {
                         "end": Object {
@@ -1159,9 +1351,9 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 8,
+              "column": 7,
               "line": 1,
-              "offset": 7,
+              "offset": 6,
             },
             "start": Object {
               "column": 6,
@@ -1170,7 +1362,23 @@ Object {
             },
           },
           "type": "separator",
-          "value": ": ",
+          "value": ":",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 8,
+              "line": 1,
+              "offset": 7,
+            },
+            "start": Object {
+              "column": 7,
+              "line": 1,
+              "offset": 6,
+            },
+          },
+          "type": "whitespace",
+          "value": " ",
         },
         Object {
           "position": Object {
@@ -1276,9 +1484,9 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 21,
+              "column": 20,
               "line": 1,
-              "offset": 20,
+              "offset": 19,
             },
             "start": Object {
               "column": 19,
@@ -1287,7 +1495,23 @@ Object {
             },
           },
           "type": "separator",
-          "value": ": ",
+          "value": ":",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 21,
+              "line": 1,
+              "offset": 20,
+            },
+            "start": Object {
+              "column": 20,
+              "line": 1,
+              "offset": 19,
+            },
+          },
+          "type": "whitespace",
+          "value": " ",
         },
         Object {
           "position": Object {
@@ -1361,9 +1585,9 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 6,
+              "column": 5,
               "line": 1,
-              "offset": 5,
+              "offset": 4,
             },
             "start": Object {
               "column": 4,
@@ -1372,7 +1596,23 @@ Object {
             },
           },
           "type": "separator",
-          "value": ": ",
+          "value": ":",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+            "start": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+          },
+          "type": "whitespace",
+          "value": " ",
         },
         Object {
           "position": Object {
@@ -1462,9 +1702,9 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 15,
+              "column": 14,
               "line": 1,
-              "offset": 14,
+              "offset": 13,
             },
             "start": Object {
               "column": 13,
@@ -1473,7 +1713,23 @@ Object {
             },
           },
           "type": "separator",
-          "value": ": ",
+          "value": ":",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 15,
+              "line": 1,
+              "offset": 14,
+            },
+            "start": Object {
+              "column": 14,
+              "line": 1,
+              "offset": 13,
+            },
+          },
+          "type": "whitespace",
+          "value": " ",
         },
         Object {
           "position": Object {
@@ -1547,9 +1803,9 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 6,
+              "column": 5,
               "line": 1,
-              "offset": 5,
+              "offset": 4,
             },
             "start": Object {
               "column": 4,
@@ -1558,7 +1814,23 @@ Object {
             },
           },
           "type": "separator",
-          "value": ": ",
+          "value": ":",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+            "start": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+          },
+          "type": "whitespace",
+          "value": " ",
         },
         Object {
           "position": Object {
@@ -1665,9 +1937,9 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 6,
+              "column": 5,
               "line": 1,
-              "offset": 5,
+              "offset": 4,
             },
             "start": Object {
               "column": 4,
@@ -1676,7 +1948,23 @@ Object {
             },
           },
           "type": "separator",
-          "value": ": ",
+          "value": ":",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+            "start": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+          },
+          "type": "whitespace",
+          "value": " ",
         },
         Object {
           "position": Object {
@@ -1783,9 +2071,9 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 6,
+              "column": 5,
               "line": 1,
-              "offset": 5,
+              "offset": 4,
             },
             "start": Object {
               "column": 4,
@@ -1794,7 +2082,23 @@ Object {
             },
           },
           "type": "separator",
-          "value": ": ",
+          "value": ":",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+            "start": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+          },
+          "type": "whitespace",
+          "value": " ",
         },
         Object {
           "position": Object {
@@ -1883,9 +2187,9 @@ Object {
             Object {
               "position": Object {
                 "end": Object {
-                  "column": 9,
+                  "column": 8,
                   "line": 4,
-                  "offset": 65,
+                  "offset": 64,
                 },
                 "start": Object {
                   "column": 7,
@@ -1894,7 +2198,23 @@ Object {
                 },
               },
               "type": "separator",
-              "value": ": ",
+              "value": ":",
+            },
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 9,
+                  "line": 4,
+                  "offset": 65,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 4,
+                  "offset": 64,
+                },
+              },
+              "type": "whitespace",
+              "value": " ",
             },
             Object {
               "children": Array [
@@ -1917,9 +2237,9 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 14,
-                  "line": 4,
-                  "offset": 70,
+                  "column": 1,
+                  "line": 5,
+                  "offset": 71,
                 },
                 "start": Object {
                   "column": 9,
@@ -2099,9 +2419,9 @@ Object {
         Object {
           "position": Object {
             "end": Object {
-              "column": 6,
+              "column": 5,
               "line": 1,
-              "offset": 5,
+              "offset": 4,
             },
             "start": Object {
               "column": 4,
@@ -2110,7 +2430,23 @@ Object {
             },
           },
           "type": "separator",
-          "value": ": ",
+          "value": ":",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+            "start": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+          },
+          "type": "whitespace",
+          "value": " ",
         },
         Object {
           "position": Object {
@@ -2247,9 +2583,9 @@ Object {
             Object {
               "position": Object {
                 "end": Object {
-                  "column": 9,
+                  "column": 8,
                   "line": 7,
-                  "offset": 101,
+                  "offset": 100,
                 },
                 "start": Object {
                   "column": 7,
@@ -2258,7 +2594,23 @@ Object {
                 },
               },
               "type": "separator",
-              "value": ": ",
+              "value": ":",
+            },
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 9,
+                  "line": 7,
+                  "offset": 101,
+                },
+                "start": Object {
+                  "column": 8,
+                  "line": 7,
+                  "offset": 100,
+                },
+              },
+              "type": "whitespace",
+              "value": " ",
             },
             Object {
               "children": Array [
@@ -2281,9 +2633,9 @@ Object {
               ],
               "position": Object {
                 "end": Object {
-                  "column": 14,
-                  "line": 7,
-                  "offset": 106,
+                  "column": 1,
+                  "line": 8,
+                  "offset": 107,
                 },
                 "start": Object {
                   "column": 9,

--- a/test/parser.js.snap
+++ b/test/parser.js.snap
@@ -747,6 +747,456 @@ Object {
 }
 `;
 
+exports[`<message> <footer> parses footer tokens with multiple whitespaces after separator 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 4,
+              "line": 1,
+              "offset": 3,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "type",
+          "value": "fix",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+            "start": Object {
+              "column": 4,
+              "line": 1,
+              "offset": 3,
+            },
+          },
+          "type": "separator",
+          "value": ":",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+            "start": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+          },
+          "type": "whitespace",
+          "value": " ",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 16,
+              "line": 1,
+              "offset": 15,
+            },
+            "start": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+          },
+          "type": "text",
+          "value": "some stuff",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 16,
+          "line": 1,
+          "offset": 15,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "summary",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 12,
+                      "line": 3,
+                      "offset": 28,
+                    },
+                    "start": Object {
+                      "column": 1,
+                      "line": 3,
+                      "offset": 17,
+                    },
+                  },
+                  "type": "type",
+                  "value": "External-Id",
+                },
+              ],
+              "position": Object {
+                "end": Object {
+                  "column": 12,
+                  "line": 3,
+                  "offset": 28,
+                },
+                "start": Object {
+                  "column": 12,
+                  "line": 3,
+                  "offset": 28,
+                },
+              },
+              "type": "token",
+            },
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 13,
+                  "line": 3,
+                  "offset": 29,
+                },
+                "start": Object {
+                  "column": 12,
+                  "line": 3,
+                  "offset": 28,
+                },
+              },
+              "type": "separator",
+              "value": ":",
+            },
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 17,
+                  "line": 3,
+                  "offset": 33,
+                },
+                "start": Object {
+                  "column": 13,
+                  "line": 3,
+                  "offset": 29,
+                },
+              },
+              "type": "whitespace",
+              "value": "    ",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 21,
+                      "line": 3,
+                      "offset": 37,
+                    },
+                    "start": Object {
+                      "column": 17,
+                      "line": 3,
+                      "offset": 33,
+                    },
+                  },
+                  "type": "text",
+                  "value": "1337",
+                },
+              ],
+              "position": Object {
+                "end": Object {
+                  "column": 21,
+                  "line": 3,
+                  "offset": 37,
+                },
+                "start": Object {
+                  "column": 17,
+                  "line": 3,
+                  "offset": 33,
+                },
+              },
+              "type": "value",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 21,
+              "line": 3,
+              "offset": 37,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 3,
+              "offset": 17,
+            },
+          },
+          "type": "footer",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 21,
+          "line": 3,
+          "offset": 37,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 3,
+          "offset": 17,
+        },
+      },
+      "type": "body",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 21,
+      "line": 3,
+      "offset": 37,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "message",
+}
+`;
+
+exports[`<message> <footer> parses footer tokens without whitespaces after separator 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 4,
+              "line": 1,
+              "offset": 3,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "type",
+          "value": "fix",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+            "start": Object {
+              "column": 4,
+              "line": 1,
+              "offset": 3,
+            },
+          },
+          "type": "separator",
+          "value": ":",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+            "start": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+          },
+          "type": "whitespace",
+          "value": " ",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 16,
+              "line": 1,
+              "offset": 15,
+            },
+            "start": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+          },
+          "type": "text",
+          "value": "some stuff",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 16,
+          "line": 1,
+          "offset": 15,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "summary",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 12,
+                      "line": 3,
+                      "offset": 28,
+                    },
+                    "start": Object {
+                      "column": 1,
+                      "line": 3,
+                      "offset": 17,
+                    },
+                  },
+                  "type": "type",
+                  "value": "External-Id",
+                },
+              ],
+              "position": Object {
+                "end": Object {
+                  "column": 12,
+                  "line": 3,
+                  "offset": 28,
+                },
+                "start": Object {
+                  "column": 12,
+                  "line": 3,
+                  "offset": 28,
+                },
+              },
+              "type": "token",
+            },
+            Object {
+              "position": Object {
+                "end": Object {
+                  "column": 13,
+                  "line": 3,
+                  "offset": 29,
+                },
+                "start": Object {
+                  "column": 12,
+                  "line": 3,
+                  "offset": 28,
+                },
+              },
+              "type": "separator",
+              "value": ":",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 17,
+                      "line": 3,
+                      "offset": 33,
+                    },
+                    "start": Object {
+                      "column": 13,
+                      "line": 3,
+                      "offset": 29,
+                    },
+                  },
+                  "type": "text",
+                  "value": "1337",
+                },
+              ],
+              "position": Object {
+                "end": Object {
+                  "column": 17,
+                  "line": 3,
+                  "offset": 33,
+                },
+                "start": Object {
+                  "column": 13,
+                  "line": 3,
+                  "offset": 29,
+                },
+              },
+              "type": "value",
+            },
+          ],
+          "position": Object {
+            "end": Object {
+              "column": 17,
+              "line": 3,
+              "offset": 33,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 3,
+              "offset": 17,
+            },
+          },
+          "type": "footer",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 17,
+          "line": 3,
+          "offset": 33,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 3,
+          "offset": 17,
+        },
+      },
+      "type": "body",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 17,
+      "line": 3,
+      "offset": 33,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "message",
+}
+`;
+
 exports[`<message> <footer> parses simple token/separator/value form of footer 1`] = `
 Object {
   "children": Array [
@@ -1561,6 +2011,123 @@ Object {
 }
 `;
 
+exports[`<message> <summary> parses summary with multiple spaces after separator 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "type",
+          "value": "feat",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 10,
+              "line": 1,
+              "offset": 9,
+            },
+            "start": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+          },
+          "type": "scope",
+          "value": "tree",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 12,
+              "line": 1,
+              "offset": 11,
+            },
+            "start": Object {
+              "column": 11,
+              "line": 1,
+              "offset": 10,
+            },
+          },
+          "type": "separator",
+          "value": ":",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 16,
+              "line": 1,
+              "offset": 15,
+            },
+            "start": Object {
+              "column": 12,
+              "line": 1,
+              "offset": 11,
+            },
+          },
+          "type": "whitespace",
+          "value": "    ",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 35,
+              "line": 1,
+              "offset": 34,
+            },
+            "start": Object {
+              "column": 16,
+              "line": 1,
+              "offset": 15,
+            },
+          },
+          "type": "text",
+          "value": "add whitespace node",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 35,
+          "line": 1,
+          "offset": 34,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "summary",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 35,
+      "line": 1,
+      "offset": 34,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "message",
+}
+`;
+
 exports[`<message> <summary> parses summary with no scope 1`] = `
 Object {
   "children": Array [
@@ -1768,6 +2335,107 @@ Object {
       "column": 37,
       "line": 1,
       "offset": 36,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "message",
+}
+`;
+
+exports[`<message> <summary> parses summary without spaces after separator 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 5,
+              "line": 1,
+              "offset": 4,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "type",
+          "value": "feat",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 10,
+              "line": 1,
+              "offset": 9,
+            },
+            "start": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+          },
+          "type": "scope",
+          "value": "tree",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 12,
+              "line": 1,
+              "offset": 11,
+            },
+            "start": Object {
+              "column": 11,
+              "line": 1,
+              "offset": 10,
+            },
+          },
+          "type": "separator",
+          "value": ":",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 31,
+              "line": 1,
+              "offset": 30,
+            },
+            "start": Object {
+              "column": 12,
+              "line": 1,
+              "offset": 11,
+            },
+          },
+          "type": "text",
+          "value": "no whitespaces here",
+        },
+      ],
+      "position": Object {
+        "end": Object {
+          "column": 31,
+          "line": 1,
+          "offset": 30,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "summary",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 31,
+      "line": 1,
+      "offset": 30,
     },
     "start": Object {
       "column": 1,


### PR DESCRIPTION
This adds the `whitespace` parsing (as mentioned in #16), it's set (by default) to greedy. I think that's great and here is why:

- When multiple whitespaces exist, it combines them into a single `whitespace` node (with exact value ofc)
- When no whitespace token exist at the current position, it still returns an error. The method where this was invoked from can either decide to abort or continue.

### Some good examples
<img width="400" alt="Screenshot 2020-12-25 at 03 38 11" src="https://user-images.githubusercontent.com/1203991/103115423-c7566780-4662-11eb-8498-f3afe301b7d3.png">
<img width="400" alt="Screenshot 2020-12-25 at 03 38 30" src="https://user-images.githubusercontent.com/1203991/103115426-c8879480-4662-11eb-8f4a-558952e33036.png">
<img width="400" alt="Screenshot 2020-12-25 at 03 38 58" src="https://user-images.githubusercontent.com/1203991/103115428-c8879480-4662-11eb-9582-54aebc13004b.png">

### But not too permissive (yet)
<img width="400" alt="Screenshot 2020-12-25 at 03 40 50" src="https://user-images.githubusercontent.com/1203991/103115518-2916d180-4663-11eb-87c3-608dd42143c2.png">
<img width="400" alt="Screenshot 2020-12-25 at 03 41 52" src="https://user-images.githubusercontent.com/1203991/103115521-2a47fe80-4663-11eb-8e0b-722745acb659.png">

