### PR TITLE
feat: add greedy newline tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ in sync with the written specification on conventionalcommits.org.
 /* Any non-newline whitespace: */
 <whitespace>      ::= <ZWNBSP> | <TAB> | <VT> | <FF> | <SP> | <NBSP> | <USP>
 
-<message>         ::= <summary>, <newline>+, <body>, <newline>*, <footer>+
-                   |  <summary>, <newline>*, <footer>+
+<message>         ::= <summary>, <newline>+, <body>, (<newline>+, <footer>)*
+                   |  <summary>, (<newline>+, <footer>)*
                    |  <summary>, <newline>*
 
 /* "!" should be added to the AST as a <breaking-change> node with the value "!" */
@@ -78,9 +78,9 @@ in sync with the written specification on conventionalcommits.org.
  * <text> tokens of <body-text> should be appended as children to <body> */
 <body-text>       ::= [<breaking-change>, ":", <whitespace>*], text
 /* Note: <pre-footer> is used during parsing, but not returned in the AST. */
-<pre-footer>      ::= <newline>*, <footer>+
+<pre-footer>      ::= <newline>+, <footer>
 
-<footer>          ::= <token>, <separator>, <whitespace>*, <value>, [<newline>]
+<footer>          ::= <token>, <separator>, <whitespace>*, <value>
 /* "!" should be added to the AST as a <breaking-change> node with the value "!" */
 <token>           ::= <breaking-change>
                    |  <type>, "(" <scope> ")", ["!"]

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -2,8 +2,8 @@ const Scanner = require('./scanner')
 const { isWhitespace, isNewline, isParens } = require('./type-checks')
 
 /*
- * <message>       ::= <summary>, <newline>*, <body>, <newline>*, <footer>+
- *                  |  <summary>, <newline>*, <footer>+
+ * <message>       ::= <summary>, <newline>+, <body>, (<newline>+, <footer>)*
+ *                  |  <summary>, (<newline>+, <footer>)*
  *                  |  <summary>, <newline>*
  *
  */
@@ -56,6 +56,12 @@ function message (commitText) {
       break
     } else {
       node.children.push(f)
+    }
+    nl = newline(scanner)
+    if (nl instanceof Error) {
+      break
+    } else {
+      node.children.push(nl)
     }
   }
 
@@ -224,8 +230,8 @@ function body (scanner) {
 function preFooter (scanner) {
   const node = scanner.enter('pre-footer', [])
   let f
-  newline(scanner)
   while (!scanner.eof()) {
+    newline(scanner)
     f = footer(scanner)
     if (f instanceof Error) return scanner.abort(node)
   }
@@ -233,7 +239,7 @@ function preFooter (scanner) {
 }
 
 /*
- * <footer>       ::= <token> <separator> <whitespace>* <value> <newline>?
+ * <footer>       ::= <token> <separator> <whitespace>* <value>
  */
 function footer (scanner) {
   const node = scanner.enter('footer', [])
@@ -267,12 +273,6 @@ function footer (scanner) {
     return v
   } else {
     node.children.push(v)
-  }
-
-  // <newline>?
-  const nl = newline(scanner)
-  if (!(nl instanceof Error)) {
-    node.children.push(nl)
   }
 
   return scanner.exit(node)

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -11,7 +11,7 @@ function message (commitText) {
   const scanner = new Scanner(commitText.trim())
   const node = scanner.enter('message', [])
 
-  // <summary>
+  // <summary> ...
   const s = summary(scanner)
   if (s instanceof Error) {
     throw s
@@ -22,27 +22,43 @@ function message (commitText) {
     return scanner.exit(node)
   }
 
-  // <summary> <newline>* <body>
-  if (isNewline(scanner.peek())) {
-    // TODO(@byCedric): include <newline>* in AST.
-    while (isNewline(scanner.peek())) {
-      scanner.next()
-    }
+  let nl
+  let b
+  // ... <newline>* <body> ...
+  nl = newline(scanner)
+  if (nl instanceof Error) {
+    throw nl
   } else {
-    throw scanner.abort(node)
+    node.children.push(nl)
+    b = body(scanner)
+    if (b instanceof Error) {
+      b = null
+    } else {
+      node.children.push(b)
+    }
   }
-  const b = body(scanner)
-  if (!(b instanceof Error)) {
-    node.children.push(b)
+  if (scanner.eof()) {
+    return scanner.exit(node)
   }
-  // TODO(@byCedric): include <newline>* in AST.
-  while (isNewline(scanner.peek())) {
-    scanner.next()
+
+  //  ... <newline>* <footer>+
+  if (b) {
+    nl = newline(scanner)
+    if (nl instanceof Error) {
+      throw nl
+    } else {
+      node.children.push(nl)
+    }
   }
   while (!scanner.eof()) {
     const f = footer(scanner)
-    if (!(f instanceof Error)) node.children.push(f)
+    if (f instanceof Error) {
+      break
+    } else {
+      node.children.push(f)
+    }
   }
+
   return scanner.exit(node)
 }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -205,8 +205,9 @@ function body (scanner) {
   const t = text(scanner)
   node.children.push(t)
   // <newline>, <body>*
-  if (isNewline(scanner.peek())) {
-    scanner.next()
+  const nl = newline(scanner)
+  if (!(nl instanceof Error)) {
+    node.children.push(nl)
     const b = body(scanner)
     if (!(b instanceof Error)) {
       Array.prototype.push.apply(node.children, b.children)
@@ -220,10 +221,8 @@ function body (scanner) {
  */
 function preFooter (scanner) {
   const node = scanner.enter('pre-footer', [])
-  while (isNewline(scanner.peek())) {
-    scanner.next()
-  }
   let f
+  newline(scanner)
   while (!scanner.eof()) {
     f = footer(scanner)
     if (f instanceof Error) return scanner.abort(node)
@@ -247,6 +246,7 @@ function footer (scanner) {
   // <separator>
   const s = separator(scanner)
   if (s instanceof Error) {
+    scanner.abort(node)
     return s
   } else {
     node.children.push(s)
@@ -258,16 +258,21 @@ function footer (scanner) {
     node.children.push(ws)
   }
 
-  // <value> <newline>?
+  // <value>
   const v = value(scanner)
   if (v instanceof Error) {
+    scanner.abort(node)
     return v
   } else {
     node.children.push(v)
   }
-  if (isNewline(scanner.peek())) {
-    scanner.next()
+
+  // <newline>?
+  const nl = newline(scanner)
+  if (!(nl instanceof Error)) {
+    node.children.push(nl)
   }
+
   return scanner.exit(node)
 }
 
@@ -346,18 +351,23 @@ function value (scanner) {
  */
 function continuation (scanner) {
   const node = scanner.enter('continuation', [])
-  if (isNewline(scanner.peek())) {
-    scanner.next()
-    const ws = whitespace(scanner)
-    if (ws instanceof Error) {
-      return ws
-    } else {
-      node.children.push(ws)
-      node.children.push(text(scanner))
-    }
+  // <newline>
+  const nl = newline(scanner)
+  if (nl instanceof Error) {
+    return nl
   } else {
-    return scanner.abort(node)
+    node.children.push(nl)
   }
+
+  // <whitespace> <text>
+  const ws = whitespace(scanner)
+  if (ws instanceof Error) {
+    return ws
+  } else {
+    node.children.push(ws)
+    node.children.push(text(scanner))
+  }
+
   return scanner.exit(node)
 }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -385,4 +385,18 @@ function whitespace (scanner) {
   return scanner.exit(node)
 }
 
+/*
+ * <newline>+       ::= [<CR>], <LF>
+ */
+function newline (scanner) {
+  const node = scanner.enter('newline', '')
+  while (isNewline(scanner.peek())) {
+    node.value += scanner.next()
+  }
+  if (node.value === '') {
+    return scanner.abort(node, ['<CR><LF>', '<LF>'])
+  }
+  return scanner.exit(node)
+}
+
 module.exports = message

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -45,6 +45,7 @@ function message (commitText) {
   if (b) {
     nl = newline(scanner)
     if (nl instanceof Error) {
+      console.log(scanner.position())
       throw nl
     } else {
       node.children.push(nl)
@@ -207,9 +208,11 @@ function body (scanner) {
   // <newline>, <body>*
   const nl = newline(scanner)
   if (!(nl instanceof Error)) {
-    node.children.push(nl)
     const b = body(scanner)
-    if (!(b instanceof Error)) {
+    if (b instanceof Error) {
+      scanner.abort(nl)
+    } else {
+      node.children.push(nl)
       Array.prototype.push.apply(node.children, b.children)
     }
   }
@@ -362,6 +365,7 @@ function continuation (scanner) {
   // <whitespace> <text>
   const ws = whitespace(scanner)
   if (ws instanceof Error) {
+    scanner.abort(node)
     return ws
   } else {
     node.children.push(ws)

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -45,7 +45,6 @@ function message (commitText) {
   if (b) {
     nl = newline(scanner)
     if (nl instanceof Error) {
-      console.log(scanner.position())
       throw nl
     } else {
       node.children.push(nl)

--- a/test/parser.js.snap
+++ b/test/parser.js.snap
@@ -85,6 +85,24 @@ Object {
       "type": "summary",
     },
     Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 3,
+          "offset": 23,
+        },
+        "start": Object {
+          "column": 22,
+          "line": 1,
+          "offset": 21,
+        },
+      },
+      "type": "newline",
+      "value": "
+
+",
+    },
+    Object {
       "children": Array [
         Object {
           "position": Object {
@@ -149,6 +167,23 @@ Object {
           },
           "type": "text",
           "value": "introduces breaking change",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 1,
+              "line": 4,
+              "offset": 67,
+            },
+            "start": Object {
+              "column": 44,
+              "line": 3,
+              "offset": 66,
+            },
+          },
+          "type": "newline",
+          "value": "
+",
         },
         Object {
           "position": Object {
@@ -283,6 +318,24 @@ Object {
       "type": "summary",
     },
     Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 3,
+          "offset": 24,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 1,
+          "offset": 22,
+        },
+      },
+      "type": "newline",
+      "value": "
+
+",
+    },
+    Object {
       "children": Array [
         Object {
           "children": Array [
@@ -370,9 +423,9 @@ Object {
           ],
           "position": Object {
             "end": Object {
-              "column": 1,
-              "line": 4,
-              "offset": 59,
+              "column": 35,
+              "line": 3,
+              "offset": 58,
             },
             "start": Object {
               "column": 18,
@@ -381,6 +434,24 @@ Object {
             },
           },
           "type": "value",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 1,
+              "line": 5,
+              "offset": 60,
+            },
+            "start": Object {
+              "column": 35,
+              "line": 3,
+              "offset": 58,
+            },
+          },
+          "type": "newline",
+          "value": "
+
+",
         },
       ],
       "position": Object {
@@ -485,9 +556,9 @@ Object {
           ],
           "position": Object {
             "end": Object {
-              "column": 1,
-              "line": 6,
-              "offset": 74,
+              "column": 14,
+              "line": 5,
+              "offset": 73,
             },
             "start": Object {
               "column": 9,
@@ -496,6 +567,23 @@ Object {
             },
           },
           "type": "value",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 1,
+              "line": 6,
+              "offset": 74,
+            },
+            "start": Object {
+              "column": 14,
+              "line": 5,
+              "offset": 73,
+            },
+          },
+          "type": "newline",
+          "value": "
+",
         },
       ],
       "position": Object {
@@ -713,6 +801,24 @@ Object {
       "type": "summary",
     },
     Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 3,
+          "offset": 24,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 1,
+          "offset": 22,
+        },
+      },
+      "type": "newline",
+      "value": "
+
+",
+    },
+    Object {
       "children": Array [
         Object {
           "position": Object {
@@ -733,9 +839,9 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 1,
-          "line": 4,
-          "offset": 57,
+          "column": 33,
+          "line": 3,
+          "offset": 56,
         },
         "start": Object {
           "column": 1,
@@ -744,6 +850,23 @@ Object {
         },
       },
       "type": "body",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 4,
+          "offset": 57,
+        },
+        "start": Object {
+          "column": 33,
+          "line": 3,
+          "offset": 56,
+        },
+      },
+      "type": "newline",
+      "value": "
+",
     },
     Object {
       "children": Array [
@@ -833,9 +956,9 @@ Object {
           ],
           "position": Object {
             "end": Object {
-              "column": 1,
-              "line": 5,
-              "offset": 71,
+              "column": 14,
+              "line": 4,
+              "offset": 70,
             },
             "start": Object {
               "column": 9,
@@ -844,6 +967,23 @@ Object {
             },
           },
           "type": "value",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 1,
+              "line": 5,
+              "offset": 71,
+            },
+            "start": Object {
+              "column": 14,
+              "line": 4,
+              "offset": 70,
+            },
+          },
+          "type": "newline",
+          "value": "
+",
         },
       ],
       "position": Object {
@@ -1061,6 +1201,24 @@ Object {
       "type": "summary",
     },
     Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 3,
+          "offset": 24,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 1,
+          "offset": 22,
+        },
+      },
+      "type": "newline",
+      "value": "
+
+",
+    },
+    Object {
       "children": Array [
         Object {
           "position": Object {
@@ -1129,6 +1287,23 @@ Object {
         Object {
           "position": Object {
             "end": Object {
+              "column": 1,
+              "line": 4,
+              "offset": 59,
+            },
+            "start": Object {
+              "column": 35,
+              "line": 3,
+              "offset": 58,
+            },
+          },
+          "type": "newline",
+          "value": "
+",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
               "column": 33,
               "line": 4,
               "offset": 91,
@@ -1145,9 +1320,9 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 1,
-          "line": 5,
-          "offset": 92,
+          "column": 33,
+          "line": 4,
+          "offset": 91,
         },
         "start": Object {
           "column": 1,
@@ -1156,6 +1331,23 @@ Object {
         },
       },
       "type": "body",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 5,
+          "offset": 92,
+        },
+        "start": Object {
+          "column": 33,
+          "line": 4,
+          "offset": 91,
+        },
+      },
+      "type": "newline",
+      "value": "
+",
     },
     Object {
       "children": Array [
@@ -1245,9 +1437,9 @@ Object {
           ],
           "position": Object {
             "end": Object {
-              "column": 1,
-              "line": 6,
-              "offset": 106,
+              "column": 14,
+              "line": 5,
+              "offset": 105,
             },
             "start": Object {
               "column": 9,
@@ -1256,6 +1448,23 @@ Object {
             },
           },
           "type": "value",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 1,
+              "line": 6,
+              "offset": 106,
+            },
+            "start": Object {
+              "column": 14,
+              "line": 5,
+              "offset": 105,
+            },
+          },
+          "type": "newline",
+          "value": "
+",
         },
       ],
       "position": Object {
@@ -1473,6 +1682,24 @@ Object {
       "type": "summary",
     },
     Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 3,
+          "offset": 24,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 1,
+          "offset": 22,
+        },
+      },
+      "type": "newline",
+      "value": "
+
+",
+    },
+    Object {
       "children": Array [
         Object {
           "position": Object {
@@ -1494,17 +1721,19 @@ Object {
           "position": Object {
             "end": Object {
               "column": 1,
-              "line": 4,
-              "offset": 59,
+              "line": 5,
+              "offset": 60,
             },
             "start": Object {
-              "column": 1,
-              "line": 4,
-              "offset": 59,
+              "column": 35,
+              "line": 3,
+              "offset": 58,
             },
           },
-          "type": "text",
-          "value": "",
+          "type": "newline",
+          "value": "
+
+",
         },
         Object {
           "position": Object {
@@ -1525,9 +1754,9 @@ Object {
       ],
       "position": Object {
         "end": Object {
-          "column": 1,
-          "line": 6,
-          "offset": 92,
+          "column": 32,
+          "line": 5,
+          "offset": 91,
         },
         "start": Object {
           "column": 1,
@@ -1536,6 +1765,24 @@ Object {
         },
       },
       "type": "body",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 7,
+          "offset": 93,
+        },
+        "start": Object {
+          "column": 32,
+          "line": 5,
+          "offset": 91,
+        },
+      },
+      "type": "newline",
+      "value": "
+
+",
     },
     Object {
       "children": Array [
@@ -1625,9 +1872,9 @@ Object {
           ],
           "position": Object {
             "end": Object {
-              "column": 1,
-              "line": 8,
-              "offset": 107,
+              "column": 14,
+              "line": 7,
+              "offset": 106,
             },
             "start": Object {
               "column": 9,
@@ -1636,6 +1883,23 @@ Object {
             },
           },
           "type": "value",
+        },
+        Object {
+          "position": Object {
+            "end": Object {
+              "column": 1,
+              "line": 8,
+              "offset": 107,
+            },
+            "start": Object {
+              "column": 14,
+              "line": 7,
+              "offset": 106,
+            },
+          },
+          "type": "newline",
+          "value": "
+",
         },
       ],
       "position": Object {
@@ -1851,6 +2115,23 @@ Object {
         },
       },
       "type": "summary",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 2,
+          "offset": 23,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 1,
+          "offset": 22,
+        },
+      },
+      "type": "newline",
+      "value": "
+",
     },
     Object {
       "children": Array [
@@ -2069,6 +2350,23 @@ Object {
       "type": "summary",
     },
     Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 2,
+          "offset": 23,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 1,
+          "offset": 22,
+        },
+      },
+      "type": "newline",
+      "value": "
+",
+    },
+    Object {
       "children": Array [
         Object {
           "children": Array [
@@ -2283,6 +2581,23 @@ Object {
         },
       },
       "type": "summary",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 2,
+          "offset": 33,
+        },
+        "start": Object {
+          "column": 33,
+          "line": 1,
+          "offset": 32,
+        },
+      },
+      "type": "newline",
+      "value": "
+",
     },
     Object {
       "children": Array [
@@ -2515,6 +2830,23 @@ Object {
         },
       },
       "type": "summary",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 2,
+          "offset": 33,
+        },
+        "start": Object {
+          "column": 33,
+          "line": 1,
+          "offset": 32,
+        },
+      },
+      "type": "newline",
+      "value": "
+",
     },
     Object {
       "children": Array [
@@ -2765,6 +3097,24 @@ Object {
       "type": "summary",
     },
     Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 3,
+          "offset": 17,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 1,
+          "offset": 15,
+        },
+      },
+      "type": "newline",
+      "value": "
+
+",
+    },
+    Object {
       "children": Array [
         Object {
           "children": Array [
@@ -2981,6 +3331,24 @@ Object {
       "type": "summary",
     },
     Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 3,
+          "offset": 17,
+        },
+        "start": Object {
+          "column": 16,
+          "line": 1,
+          "offset": 15,
+        },
+      },
+      "type": "newline",
+      "value": "
+
+",
+    },
+    Object {
       "children": Array [
         Object {
           "children": Array [
@@ -3179,6 +3547,23 @@ Object {
         },
       },
       "type": "summary",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 2,
+          "offset": 23,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 1,
+          "offset": 22,
+        },
+      },
+      "type": "newline",
+      "value": "
+",
     },
     Object {
       "children": Array [
@@ -3397,6 +3782,23 @@ Object {
       "type": "summary",
     },
     Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 2,
+          "offset": 23,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 1,
+          "offset": 22,
+        },
+      },
+      "type": "newline",
+      "value": "
+",
+    },
+    Object {
       "children": Array [
         Object {
           "children": Array [
@@ -3486,6 +3888,23 @@ Object {
                 Object {
                   "position": Object {
                     "end": Object {
+                      "column": 1,
+                      "line": 3,
+                      "offset": 70,
+                    },
+                    "start": Object {
+                      "column": 47,
+                      "line": 2,
+                      "offset": 69,
+                    },
+                  },
+                  "type": "newline",
+                  "value": "
+",
+                },
+                Object {
+                  "position": Object {
+                    "end": Object {
                       "column": 2,
                       "line": 3,
                       "offset": 71,
@@ -3532,6 +3951,23 @@ Object {
             },
             Object {
               "children": Array [
+                Object {
+                  "position": Object {
+                    "end": Object {
+                      "column": 1,
+                      "line": 4,
+                      "offset": 102,
+                    },
+                    "start": Object {
+                      "column": 32,
+                      "line": 3,
+                      "offset": 101,
+                    },
+                  },
+                  "type": "newline",
+                  "value": "
+",
+                },
                 Object {
                   "position": Object {
                     "end": Object {
@@ -4397,6 +4833,24 @@ Object {
       "type": "summary",
     },
     Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 3,
+          "offset": 24,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 1,
+          "offset": 22,
+        },
+      },
+      "type": "newline",
+      "value": "
+
+",
+    },
+    Object {
       "children": Array [
         Object {
           "position": Object {
@@ -4529,6 +4983,23 @@ Object {
         },
       },
       "type": "summary",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 2,
+          "offset": 23,
+        },
+        "start": Object {
+          "column": 23,
+          "line": 1,
+          "offset": 22,
+        },
+      },
+      "type": "newline",
+      "value": "
+",
     },
     Object {
       "children": Array [

--- a/test/parser.js.snap
+++ b/test/parser.js.snap
@@ -435,30 +435,12 @@ Object {
           },
           "type": "value",
         },
-        Object {
-          "position": Object {
-            "end": Object {
-              "column": 1,
-              "line": 5,
-              "offset": 60,
-            },
-            "start": Object {
-              "column": 35,
-              "line": 3,
-              "offset": 58,
-            },
-          },
-          "type": "newline",
-          "value": "
-
-",
-        },
       ],
       "position": Object {
         "end": Object {
-          "column": 1,
-          "line": 5,
-          "offset": 60,
+          "column": 35,
+          "line": 3,
+          "offset": 58,
         },
         "start": Object {
           "column": 1,
@@ -467,6 +449,24 @@ Object {
         },
       },
       "type": "footer",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 5,
+          "offset": 60,
+        },
+        "start": Object {
+          "column": 35,
+          "line": 3,
+          "offset": 58,
+        },
+      },
+      "type": "newline",
+      "value": "
+
+",
     },
     Object {
       "children": Array [
@@ -568,29 +568,12 @@ Object {
           },
           "type": "value",
         },
-        Object {
-          "position": Object {
-            "end": Object {
-              "column": 1,
-              "line": 6,
-              "offset": 74,
-            },
-            "start": Object {
-              "column": 14,
-              "line": 5,
-              "offset": 73,
-            },
-          },
-          "type": "newline",
-          "value": "
-",
-        },
       ],
       "position": Object {
         "end": Object {
-          "column": 1,
-          "line": 6,
-          "offset": 74,
+          "column": 14,
+          "line": 5,
+          "offset": 73,
         },
         "start": Object {
           "column": 1,
@@ -599,6 +582,23 @@ Object {
         },
       },
       "type": "footer",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 6,
+          "offset": 74,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 5,
+          "offset": 73,
+        },
+      },
+      "type": "newline",
+      "value": "
+",
     },
     Object {
       "children": Array [
@@ -968,29 +968,12 @@ Object {
           },
           "type": "value",
         },
-        Object {
-          "position": Object {
-            "end": Object {
-              "column": 1,
-              "line": 5,
-              "offset": 71,
-            },
-            "start": Object {
-              "column": 14,
-              "line": 4,
-              "offset": 70,
-            },
-          },
-          "type": "newline",
-          "value": "
-",
-        },
       ],
       "position": Object {
         "end": Object {
-          "column": 1,
-          "line": 5,
-          "offset": 71,
+          "column": 14,
+          "line": 4,
+          "offset": 70,
         },
         "start": Object {
           "column": 1,
@@ -999,6 +982,23 @@ Object {
         },
       },
       "type": "footer",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 5,
+          "offset": 71,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 4,
+          "offset": 70,
+        },
+      },
+      "type": "newline",
+      "value": "
+",
     },
     Object {
       "children": Array [
@@ -1449,29 +1449,12 @@ Object {
           },
           "type": "value",
         },
-        Object {
-          "position": Object {
-            "end": Object {
-              "column": 1,
-              "line": 6,
-              "offset": 106,
-            },
-            "start": Object {
-              "column": 14,
-              "line": 5,
-              "offset": 105,
-            },
-          },
-          "type": "newline",
-          "value": "
-",
-        },
       ],
       "position": Object {
         "end": Object {
-          "column": 1,
-          "line": 6,
-          "offset": 106,
+          "column": 14,
+          "line": 5,
+          "offset": 105,
         },
         "start": Object {
           "column": 1,
@@ -1480,6 +1463,23 @@ Object {
         },
       },
       "type": "footer",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 6,
+          "offset": 106,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 5,
+          "offset": 105,
+        },
+      },
+      "type": "newline",
+      "value": "
+",
     },
     Object {
       "children": Array [
@@ -1884,29 +1884,12 @@ Object {
           },
           "type": "value",
         },
-        Object {
-          "position": Object {
-            "end": Object {
-              "column": 1,
-              "line": 8,
-              "offset": 107,
-            },
-            "start": Object {
-              "column": 14,
-              "line": 7,
-              "offset": 106,
-            },
-          },
-          "type": "newline",
-          "value": "
-",
-        },
       ],
       "position": Object {
         "end": Object {
-          "column": 1,
-          "line": 8,
-          "offset": 107,
+          "column": 14,
+          "line": 7,
+          "offset": 106,
         },
         "start": Object {
           "column": 1,
@@ -1915,6 +1898,23 @@ Object {
         },
       },
       "type": "footer",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 8,
+          "offset": 107,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 7,
+          "offset": 106,
+        },
+      },
+      "type": "newline",
+      "value": "
+",
     },
     Object {
       "children": Array [


### PR DESCRIPTION
Part of #16 and building on top of #24, using the same greedy principle as `whitespace` nodes.

<img width="400" alt="Screenshot 2020-12-25 at 15 34 14" src="https://user-images.githubusercontent.com/1203991/103137189-06b69f80-46c7-11eb-80ea-b4c39a2446cb.png">

It's still a draft, at least until we decided to merge or change #24. Also running into this issue where we trim the outer newlines/whitespaces. Might be better to either not-do that, to maintain positioning within the raw input.

<img width="400" alt="Screenshot 2020-12-25 at 15 38 15" src="https://user-images.githubusercontent.com/1203991/103137213-35cd1100-46c7-11eb-8246-1e5088818c3e.png">
