### PR TITLE
feat(conventional-changelog): populate references array

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 const visit = require('unist-util-visit')
+const NUMBER_REGEX = /^[0-9]+$/
 
 // Converts conventional commit AST into conventional-changelog's
 // output format, see: https://www.npmjs.com/package/conventional-commits-parser
@@ -16,9 +17,7 @@ function toConventionalChangelogFormat (ast) {
   let summary
   // Separate the body and summary nodes, this simplifies the subsequent
   // tree walking logic:
-  visit(ast, (node) => {
-    if (node.type === 'summary' || node.type === 'body') return true
-  }, (node) => {
+  visit(ast, ['body', 'summary'], (node) => {
     switch (node.type) {
       case 'body':
         body = node
@@ -74,6 +73,51 @@ function toConventionalChangelogFormat (ast) {
     if (!breaking.text) breaking.text = cc.subject
     cc.notes.push(breaking)
   }
+
+  // Populates references array from footers:
+  // references: [{
+  //    action: 'Closes',
+  //    owner: null,
+  //    repository: null,
+  //    issue: '1', raw: '#1',
+  //    prefix: '#'
+  // }]
+  visit(ast, ['footer'], (node) => {
+    const reference = {
+      prefix: '#'
+    }
+    let hasRefSepartor = false
+    visit(node, ['type', 'separator', 'text'], (node) => {
+      switch (node.type) {
+        case 'type':
+          // refs, closes, etc:
+          // TODO(@bcoe): conventional-changelog does not currently use
+          // these values in its template.
+          reference.action = node.value
+          break
+        case 'separator':
+          // Footer of the form Refs #99:
+          if (node.value.includes('#')) hasRefSepartor = true
+          break
+        case 'text':
+          // Footer of the form Refs: #99
+          // TODO(@bcoe): rethink how references like v8:8940 should work.
+          if (node.value.charAt(0) === '#') {
+            hasRefSepartor = true
+            reference.issue = node.value.substring(1)
+          // TODO(@bcoe): what about references like Refs: #99, #102?
+          } else {
+            reference.issue = node.value
+          }
+          break
+        default:
+          break
+      }
+    })
+    if (hasRefSepartor && reference.issue.match(NUMBER_REGEX)) {
+      cc.references.push(reference)
+    }
+  })
 
   return cc
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -92,20 +92,19 @@ function toConventionalChangelogFormat (ast) {
         case 'type':
           // refs, closes, etc:
           // TODO(@bcoe): conventional-changelog does not currently use
-          // these values in its template.
+          // "reference.action" in its templates:
           reference.action = node.value
           break
         case 'separator':
-          // Footer of the form Refs #99:
+          // Footer of the form "Refs #99":
           if (node.value.includes('#')) hasRefSepartor = true
           break
         case 'text':
-          // Footer of the form Refs: #99
-          // TODO(@bcoe): rethink how references like v8:8940 should work.
+          // Footer of the form "Refs: #99"
           if (node.value.charAt(0) === '#') {
             hasRefSepartor = true
             reference.issue = node.value.substring(1)
-          // TODO(@bcoe): what about references like Refs: #99, #102?
+          // TODO(@bcoe): what about references like "Refs: #99, #102"?
           } else {
             reference.issue = node.value
           }
@@ -114,6 +113,7 @@ function toConventionalChangelogFormat (ast) {
           break
       }
     })
+    // TODO(@bcoe): how should references like "Refs: v8:8940" work.
     if (hasRefSepartor && reference.issue.match(NUMBER_REGEX)) {
       cc.references.push(reference)
     }

--- a/test/utils.js
+++ b/test/utils.js
@@ -24,5 +24,21 @@ describe('utils', () => {
       assert.strictEqual(note.title, 'BREAKING CHANGE')
       assert.strictEqual(note.text, 'hello world')
     })
+    it('populates references entry from footer', () => {
+      const parsed = toConventionalChangelogFormat(parser('foo: summary\n\nRefs #34'))
+      assert.strictEqual(parsed.references.length, 1)
+      const reference = parsed.references[0]
+      assert.strictEqual(reference.issue, '34')
+    })
+    it('populates reference with ":" separator', () => {
+      const parsed = toConventionalChangelogFormat(parser('foo: summary\n\nRefs: #34'))
+      assert.strictEqual(parsed.references.length, 1)
+      const reference = parsed.references[0]
+      assert.strictEqual(reference.issue, '34')
+    })
+    it('does not populate reference, if it is non-numeric', () => {
+      const parsed = toConventionalChangelogFormat(parser('foo: summary\n\nRefs #batman'))
+      assert.strictEqual(parsed.references.length, 0)
+    })
   })
 })

--- a/test/utils.js
+++ b/test/utils.js
@@ -36,7 +36,7 @@ describe('utils', () => {
       const reference = parsed.references[0]
       assert.strictEqual(reference.issue, '34')
     })
-    it('does not populate reference, if it is non-numeric', () => {
+    it('does not populate reference if it is not numeric', () => {
       const parsed = toConventionalChangelogFormat(parser('foo: summary\n\nRefs #batman'))
       assert.strictEqual(parsed.references.length, 0)
     })


### PR DESCRIPTION
Populate `references` array in conventional-changelog format commit, based on footers like "Refs: #99`, "Refs #99".

This gets most of the unit tests passing in [release-please](https://github.com/googleapis/release-please) using `@conventional-commits/parser` rather than the conventional changelog parser.