### PR TITLE
refactor: move newline outside footer as sibling

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ in sync with the written specification on conventionalcommits.org.
 /* Any non-newline whitespace: */
 <whitespace>      ::= <ZWNBSP> | <TAB> | <VT> | <FF> | <SP> | <NBSP> | <USP>
 
-<message>         ::= <summary>, <newline>+, <body>, <newline>*, <footer>+
-                   |  <summary>, <newline>*, <footer>+
+<message>         ::= <summary>, <newline>+, <body>, (<newline>+, <footer>)*
+                   |  <summary>, (<newline>+, <footer>)*
                    |  <summary>, <newline>*
 
 /* "!" should be added to the AST as a <breaking-change> node with the value "!" */
@@ -78,9 +78,9 @@ in sync with the written specification on conventionalcommits.org.
  * <text> tokens of <body-text> should be appended as children to <body> */
 <body-text>       ::= [<breaking-change>, ":", <whitespace>*], text
 /* Note: <pre-footer> is used during parsing, but not returned in the AST. */
-<pre-footer>      ::= <newline>*, <footer>+
+<pre-footer>      ::= <newline>+, <footer>
 
-<footer>          ::= <token>, <separator>, <whitespace>*, <value>, [<newline>]
+<footer>          ::= <token>, <separator>, <whitespace>*, <value>
 /* "!" should be added to the AST as a <breaking-change> node with the value "!" */
 <token>           ::= <breaking-change>
                    |  <type>, "(" <scope> ")", ["!"]

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -2,8 +2,8 @@ const Scanner = require('./scanner')
 const { isWhitespace, isNewline, isParens } = require('./type-checks')
 
 /*
- * <message>       ::= <summary>, <newline>*, <body>, <newline>*, <footer>+
- *                  |  <summary>, <newline>*, <footer>+
+ * <message>       ::= <summary>, <newline>+, <body>, (<newline>+, <footer>)*
+ *                  |  <summary>, (<newline>+, <footer>)*
  *                  |  <summary>, <newline>*
  *
  */
@@ -56,6 +56,12 @@ function message (commitText) {
       break
     } else {
       node.children.push(f)
+    }
+    nl = newline(scanner)
+    if (nl instanceof Error) {
+      break
+    } else {
+      node.children.push(nl)
     }
   }
 
@@ -224,8 +230,8 @@ function body (scanner) {
 function preFooter (scanner) {
   const node = scanner.enter('pre-footer', [])
   let f
-  newline(scanner)
   while (!scanner.eof()) {
+    newline(scanner)
     f = footer(scanner)
     if (f instanceof Error) return scanner.abort(node)
   }
@@ -233,7 +239,7 @@ function preFooter (scanner) {
 }
 
 /*
- * <footer>       ::= <token> <separator> <whitespace>* <value> <newline>?
+ * <footer>       ::= <token> <separator> <whitespace>* <value>
  */
 function footer (scanner) {
   const node = scanner.enter('footer', [])
@@ -267,12 +273,6 @@ function footer (scanner) {
     return v
   } else {
     node.children.push(v)
-  }
-
-  // <newline>?
-  const nl = newline(scanner)
-  if (!(nl instanceof Error)) {
-    node.children.push(nl)
   }
 
   return scanner.exit(node)

--- a/test/parser.js.snap
+++ b/test/parser.js.snap
@@ -435,30 +435,12 @@ Object {
           },
           "type": "value",
         },
-        Object {
-          "position": Object {
-            "end": Object {
-              "column": 1,
-              "line": 5,
-              "offset": 60,
-            },
-            "start": Object {
-              "column": 35,
-              "line": 3,
-              "offset": 58,
-            },
-          },
-          "type": "newline",
-          "value": "
-
-",
-        },
       ],
       "position": Object {
         "end": Object {
-          "column": 1,
-          "line": 5,
-          "offset": 60,
+          "column": 35,
+          "line": 3,
+          "offset": 58,
         },
         "start": Object {
           "column": 1,
@@ -467,6 +449,24 @@ Object {
         },
       },
       "type": "footer",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 5,
+          "offset": 60,
+        },
+        "start": Object {
+          "column": 35,
+          "line": 3,
+          "offset": 58,
+        },
+      },
+      "type": "newline",
+      "value": "
+
+",
     },
     Object {
       "children": Array [
@@ -568,29 +568,12 @@ Object {
           },
           "type": "value",
         },
-        Object {
-          "position": Object {
-            "end": Object {
-              "column": 1,
-              "line": 6,
-              "offset": 74,
-            },
-            "start": Object {
-              "column": 14,
-              "line": 5,
-              "offset": 73,
-            },
-          },
-          "type": "newline",
-          "value": "
-",
-        },
       ],
       "position": Object {
         "end": Object {
-          "column": 1,
-          "line": 6,
-          "offset": 74,
+          "column": 14,
+          "line": 5,
+          "offset": 73,
         },
         "start": Object {
           "column": 1,
@@ -599,6 +582,23 @@ Object {
         },
       },
       "type": "footer",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 6,
+          "offset": 74,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 5,
+          "offset": 73,
+        },
+      },
+      "type": "newline",
+      "value": "
+",
     },
     Object {
       "children": Array [
@@ -968,29 +968,12 @@ Object {
           },
           "type": "value",
         },
-        Object {
-          "position": Object {
-            "end": Object {
-              "column": 1,
-              "line": 5,
-              "offset": 71,
-            },
-            "start": Object {
-              "column": 14,
-              "line": 4,
-              "offset": 70,
-            },
-          },
-          "type": "newline",
-          "value": "
-",
-        },
       ],
       "position": Object {
         "end": Object {
-          "column": 1,
-          "line": 5,
-          "offset": 71,
+          "column": 14,
+          "line": 4,
+          "offset": 70,
         },
         "start": Object {
           "column": 1,
@@ -999,6 +982,23 @@ Object {
         },
       },
       "type": "footer",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 5,
+          "offset": 71,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 4,
+          "offset": 70,
+        },
+      },
+      "type": "newline",
+      "value": "
+",
     },
     Object {
       "children": Array [
@@ -1449,29 +1449,12 @@ Object {
           },
           "type": "value",
         },
-        Object {
-          "position": Object {
-            "end": Object {
-              "column": 1,
-              "line": 6,
-              "offset": 106,
-            },
-            "start": Object {
-              "column": 14,
-              "line": 5,
-              "offset": 105,
-            },
-          },
-          "type": "newline",
-          "value": "
-",
-        },
       ],
       "position": Object {
         "end": Object {
-          "column": 1,
-          "line": 6,
-          "offset": 106,
+          "column": 14,
+          "line": 5,
+          "offset": 105,
         },
         "start": Object {
           "column": 1,
@@ -1480,6 +1463,23 @@ Object {
         },
       },
       "type": "footer",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 6,
+          "offset": 106,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 5,
+          "offset": 105,
+        },
+      },
+      "type": "newline",
+      "value": "
+",
     },
     Object {
       "children": Array [
@@ -1884,29 +1884,12 @@ Object {
           },
           "type": "value",
         },
-        Object {
-          "position": Object {
-            "end": Object {
-              "column": 1,
-              "line": 8,
-              "offset": 107,
-            },
-            "start": Object {
-              "column": 14,
-              "line": 7,
-              "offset": 106,
-            },
-          },
-          "type": "newline",
-          "value": "
-",
-        },
       ],
       "position": Object {
         "end": Object {
-          "column": 1,
-          "line": 8,
-          "offset": 107,
+          "column": 14,
+          "line": 7,
+          "offset": 106,
         },
         "start": Object {
           "column": 1,
@@ -1915,6 +1898,23 @@ Object {
         },
       },
       "type": "footer",
+    },
+    Object {
+      "position": Object {
+        "end": Object {
+          "column": 1,
+          "line": 8,
+          "offset": 107,
+        },
+        "start": Object {
+          "column": 14,
+          "line": 7,
+          "offset": 106,
+        },
+      },
+      "type": "newline",
+      "value": "
+",
     },
     Object {
       "children": Array [


### PR DESCRIPTION
Building on top of #25 for [this comment](https://github.com/conventional-commits/parser/pull/25#issuecomment-751298344), this pulls the `newline` outside of the `footer` node. We could discuss this a bit more before merging, or just close it and keep it the way it is. With this change, we get the following output:

<img width="400" alt="Screenshot 2020-12-31 at 15 42 52" src="https://user-images.githubusercontent.com/1203991/103414581-d9626980-4b7e-11eb-8763-2ede48c995b7.png">

> Note, if this lands, we could consider removing the `message.trim()` to include trailing newlines.