### PR TITLE
chore: run tests on main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [ assigned, opened, synchronize, reopened, labeled ]
 name: ci


### PR DESCRIPTION
I found the CI workflow hasn't run on `main` branch because the workflow specifies `master` branch. This pull request fixes it.