### PR TITLE
Fix missing type in TS definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -87,7 +87,7 @@ export interface BreakingChange extends Literal {
 
 export interface Summary extends Parent {
   type: 'summary';
-  children: (Type | Scope | Separator)[];
+  children: (Type | Scope | Separator | Text)[];
 }
 
 export interface Type extends Literal {


### PR DESCRIPTION
There's an inconsistency with the data returned and the typings. The summary should include `Text` as a possible child.