### PR TITLE
Fails to parse when body includes something that looks like a scope with new line

### DIFF
--- a/test/parser.js
+++ b/test/parser.js
@@ -131,6 +131,12 @@ describe('<message>', () => {
       assertNodePositions('fix: address major bug\n\nthis is the first line of the body\n\nthis is the second line of body\n\nAuthor: @bcoe\nRefs #392')
     })
   })
+  describe('issues', () => {
+    it('#tbd Renovate commit fails to parse', () => {
+      const parsed = parser(`fix(foo): some renovate commit\n\nfoo(\n)`)
+      console.log(parsed)
+    })
+  })
 })
 
 function assertNodePositions (text) {

--- a/test/parser.js
+++ b/test/parser.js
@@ -132,9 +132,14 @@ describe('<message>', () => {
     })
   })
   describe('issues', () => {
-    it('#tbd Renovate commit fails to parse', () => {
+    it('#48 Fails to parse when body includes something that looks like a scope', () => {
       const parsed = parser(`fix(foo): some renovate commit\n\nfoo(\n)`)
-      console.log(parsed)
+
+      expect(parsed).to.have.nested.property('children[2].type', 'body')
+      expect(parsed).to.have.nested.property('children[2].children[0]').to.deep.include({ type: 'text', value: 'foo(' })
+      expect(parsed).to.have.nested.property('children[2].children[1]').to.deep.include({ type: 'newline', value: '\n' })
+      expect(parsed).to.have.nested.property('children[2].children[2]').to.deep.include({ type: 'text', value: ')' })
+
     })
   })
 })

--- a/test/parser.js
+++ b/test/parser.js
@@ -139,7 +139,6 @@ describe('<message>', () => {
       expect(parsed).to.have.nested.property('children[2].children[0]').to.deep.include({ type: 'text', value: 'foo(' })
       expect(parsed).to.have.nested.property('children[2].children[1]').to.deep.include({ type: 'newline', value: '\n' })
       expect(parsed).to.have.nested.property('children[2].children[2]').to.deep.include({ type: 'text', value: ')' })
-
     })
   })
 })


### PR DESCRIPTION
I originally came across this when [release-please](https://github.com/googleapis/release-please) didn't pick up one of our commits. Eventually I tracked it down to this package. I'm creating a PR, mostly to provide the failing test showing the issue. I minimized the test as much as possible, here's a snippet of the original text from the commit that failed to parse, if that's helpful:

```
    ```graphql
@&#8203;link(url: "https://specs.apollo.dev/federation/v2.6", import:
[..., "@&#8203;policy"])
    ```
```

The code block is a result of the text in this PR [apollographql/federation#2818](https://github.com/apollographql/federation/pull/2818) ending up in one of our [Renovate](https://github.com/renovatebot/renovate) PR's and subsequently commit body.