### PR TITLE
fix(types): add missing summary breaking change type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -80,14 +80,19 @@ export interface Newline extends Literal {
   value: string;
 }
 
-export interface BreakingChange extends Literal {
+export interface BreakingChangeFooter extends Literal {
   type: 'breaking-change';
-  value: '!' | 'BREAKING-CHANGE' | 'BREAKING CHANGE';
+  value: 'BREAKING-CHANGE' | 'BREAKING CHANGE';
+}
+
+export interface BreakingChangeSummary extends Literal {
+  type: 'breaking-change';
+  value: '!';
 }
 
 export interface Summary extends Parent {
   type: 'summary';
-  children: (Type | Scope | Separator)[];
+  children: (Type | Scope | BreakingChangeSummary | Separator)[];
 }
 
 export interface Type extends Literal {
@@ -117,7 +122,7 @@ export interface Footer extends Parent {
 
 export interface Token extends Parent {
   type: 'token';
-  children: (Type | Scope | BreakingChange)[];
+  children: (Type | Scope | BreakingChangeFooter)[];
 }
 
 export interface Value extends Parent {


### PR DESCRIPTION
This commit solves two issues: it adds the missing breaking change type for the summary child nodes and it improves the breaking change type by splitting it up into separate types. One for the summary with the exclamation mark, and another for the breaking change footer text. This implementation should be closer to what is described in the specification[^1], item 1.

Closes #52 

[^1]: https://www.conventionalcommits.org/en/v1.0.0/#specification